### PR TITLE
Crafting skill split

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,7 +642,9 @@
                     <div id = "crafting_window" class="crafting_window">
                         <div id="crafting_mainpage_buttons" class="activable_buttons crafting_mainpage_buttons">
                             <div class="crafting_mainpage_button active_selection_button" onclick="switchCraftingRecipesPage('crafting')">Crafting</div>
+                            <div class="crafting_mainpage_button" onclick="switchCraftingRecipesPage('butchering')">Butchering</div>
                             <div class="crafting_mainpage_button" onclick="switchCraftingRecipesPage('cooking')">Cooking</div>
+                            <div class="crafting_mainpage_button" onclick="switchCraftingRecipesPage('woodworking')">Woodworking</div>
                             <div class="crafting_mainpage_button" onclick="switchCraftingRecipesPage('smelting')">Smelting</div>
                             <div class="crafting_mainpage_button" onclick="switchCraftingRecipesPage('forging')">Forging</div>
                             <div class="crafting_mainpage_button" onclick="switchCraftingRecipesPage('alchemy')">Alchemy</div>

--- a/src/crafting_recipes.js
+++ b/src/crafting_recipes.js
@@ -9,6 +9,8 @@ const cooking_recipes = {items: {}};
 const smelting_recipes = {items: {}};
 const forging_recipes = {items: {}, components: {}};
 const alchemy_recipes = {items: {}};
+const butchering_recipes = { items: {} };
+const woodworking_recipes = {items: {}, components: {}};
 
 /*
     recipes can be treated differently for display based on if they are in items/components/equipment category
@@ -406,9 +408,6 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
     crafting_recipes.components["Short hilt"] = new ComponentRecipe({
         name: "Short hilt",
         materials: [
-            {material_id: "Processed rough wood", count: 1, result_id: "Simple short wooden hilt"},
-            {material_id: "Processed wood", count: 1, result_id: "Short wooden hilt"},
-            {material_id: "Processed ash wood", count: 1, result_id: "Short ash wood hilt"},
             {material_id: "Processed weak monster bone", count: 1, result_id: "Short weak bone hilt"},
         ],
         item_type: "Component",
@@ -417,9 +416,6 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
     crafting_recipes.components["Medium handle"] = new ComponentRecipe({
         name: "Medium handle",
         materials: [
-            {material_id: "Processed rough wood", count: 2, result_id: "Simple medium wooden handle"},
-            {material_id: "Processed wood", count: 2, result_id: "Medium wooden handle"},
-            {material_id: "Processed ash wood", count: 2, result_id: "Medium ash wood handle"},
             {material_id: "Processed weak monster bone", count: 2, result_id: "Medium weak bone handle"},
         ],
         item_type: "Component",
@@ -428,19 +424,47 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
     crafting_recipes.components["Long shaft"] = new ComponentRecipe({
         name: "Long shaft",
         materials: [
-            {material_id: "Processed rough wood", count: 4, result_id: "Simple long wooden shaft"},
-            {material_id: "Processed wood", count: 4, result_id: "Long wooden shaft"},
-            {material_id: "Processed ash wood", count: 4, result_id: "Long ash wood shaft"},
             {material_id: "Processed weak monster bone", count: 4, result_id: "Long weak bone shaft"},
         ],
         item_type: "Component",
         recipe_skill: "Crafting",
     });
+
+    woodworking_recipes.components["Short hilt"] = new ComponentRecipe({
+        name: "Short hilt",
+        materials: [
+            {material_id: "Processed rough wood", count: 1, result_id: "Simple short wooden hilt"},
+            {material_id: "Processed wood", count: 1, result_id: "Short wooden hilt"},
+            {material_id: "Processed ash wood", count: 1, result_id: "Short ash wood hilt"},
+        ],
+        item_type: "Component",
+        recipe_skill: "Woodworking",
+    });
+    woodworking_recipes.components["Medium handle"] = new ComponentRecipe({
+        name: "Medium handle",
+        materials: [
+            {material_id: "Processed rough wood", count: 2, result_id: "Simple medium wooden handle"},
+            {material_id: "Processed wood", count: 2, result_id: "Medium wooden handle"},
+            {material_id: "Processed ash wood", count: 2, result_id: "Medium ash wood handle"},
+        ],
+        item_type: "Component",
+        recipe_skill: "Woodworking",
+    });
+    woodworking_recipes.components["Long shaft"] = new ComponentRecipe({
+        name: "Long shaft",
+        materials: [
+            {material_id: "Processed rough wood", count: 4, result_id: "Simple long wooden shaft"},
+            {material_id: "Processed wood", count: 4, result_id: "Long wooden shaft"},
+            {material_id: "Processed ash wood", count: 4, result_id: "Long ash wood shaft"},
+        ],
+        item_type: "Component",
+        recipe_skill: "Woodworking",
+    });
 })();
 
 //shield components
 (()=>{
-    crafting_recipes.components["Shield base"] = new ComponentRecipe({
+    woodworking_recipes.components["Shield base"] = new ComponentRecipe({
         name: "Shield base",
         materials: [
             {material_id: "Processed rough wood", count: 6, result_id: "Crude wooden shield base"}, 
@@ -448,11 +472,11 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
             {material_id: "Processed ash wood", count: 6, result_id: "Ash wood shield base"},
         ],
         item_type: "Component",
-        recipe_skill: "Crafting",
+        recipe_skill: "Woodworking",
         component_type: "shield base",
     });
 
-    crafting_recipes.components["Shield handle"] = new ComponentRecipe({
+    woodworking_recipes.components["Shield handle"] = new ComponentRecipe({
         name: "Shield handle",
         materials: [
             {material_id: "Processed rough wood", count: 4, result_id: "Basic shield handle"}, 
@@ -460,7 +484,7 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
             {material_id: "Processed ash wood", count: 4, result_id: "Ash wood shield handle"},
         ],
         item_type: "Component",
-        recipe_skill: "Crafting",
+        recipe_skill: "Woodworking",
         component_type: "shield handle",
     });
 
@@ -740,83 +764,77 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
 
 //materials
 (function(){
-    crafting_recipes.items["Piece of wolf rat leather"] = new ItemRecipe({
+    butchering_recipes.items["Piece of wolf rat leather"] = new ItemRecipe({
         name: "Piece of wolf rat leather",
         recipe_type: "material",
         materials: [{material_id: "Rat pelt", count: 6}], 
         result: {result_id: "Piece of wolf rat leather", count: 1},
         success_chance: [0.4,1],
         recipe_level: [1,5],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     });
-    crafting_recipes.items["Piece of wolf leather"] = new ItemRecipe({
+    butchering_recipes.items["Piece of wolf leather"] = new ItemRecipe({
         name: "Piece of wolf leather",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Wolf pelt", count: 6}], 
         result: {result_id: "Piece of wolf leather", count: 1},
         success_chance: [0.2,1],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
         recipe_level: [1,10],
     });
-    crafting_recipes.items["Piece of boar leather"] = new ItemRecipe({
+    butchering_recipes.items["Piece of boar leather"] = new ItemRecipe({
         name: "Piece of boar leather",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Boar hide", count: 6}],
         result: {result_id: "Piece of boar leather", count: 1},
         success_chance: [0.2,1],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
         recipe_level: [5,15],
     });
-    crafting_recipes.items["Piece of goat leather"] = new ItemRecipe({
+    butchering_recipes.items["Piece of goat leather"] = new ItemRecipe({
         name: "Piece of goat leather",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Mountain goat hide", count: 6}],
         result: {result_id: "Piece of goat leather", count: 1},
         success_chance: [0.2,1],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
         recipe_level: [5,15],
     });
-    crafting_recipes.items["Processed rat pelt"] = new ItemRecipe({
+    butchering_recipes.items["Processed rat pelt"] = new ItemRecipe({
         name: "Processed rat pelt",
         recipe_type: "material",
         materials: [{material_id: "Rat pelt", count: 6}],
         result: {result_id: "Processed rat pelt", count: 1},
         success_chance: [0.4,1],
         recipe_level: [1,5],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     });
-    crafting_recipes.items["Processed wolf pelt"] = new ItemRecipe({
+    butchering_recipes.items["Processed wolf pelt"] = new ItemRecipe({
         name: "Processed wolf pelt",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Wolf pelt", count: 6}],
         result: {result_id: "Processed wolf pelt", count: 1},
         success_chance: [0.2,1],
         recipe_level: [1,10],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     });
-    crafting_recipes.items["Processed boar hide"] = new ItemRecipe({
+    butchering_recipes.items["Processed boar hide"] = new ItemRecipe({
         name: "Processed boar hide",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Boar hide", count: 6}],
         result: {result_id: "Processed boar hide", count: 1},
         success_chance: [0.2,1],
         recipe_level: [5,15],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     });
-    crafting_recipes.items["Processed goat hide"] = new ItemRecipe({
+    butchering_recipes.items["Processed goat hide"] = new ItemRecipe({
         name: "Processed goat hide",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Mountain goat hide", count: 6}],
         result: {result_id: "Processed goat hide", count: 1},
         success_chance: [0.2,1],
         recipe_level: [5,15],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     });
     crafting_recipes.items["Wool cloth"] = new ItemRecipe({
         name: "Wool cloth",
@@ -857,14 +875,14 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         recipe_level: [10,20],
     });
 
-    crafting_recipes.items["Rat meat chunks"] = new ItemRecipe({
+    butchering_recipes.items["Rat meat chunks"] = new ItemRecipe({
         name: "Rat meat chunks",
         recipe_type: "material",
         materials: [{material_id: "Rat tail", count: 3}],
         result: {result_id: "Rat meat chunks", count: 1},
         success_chance: [0.4,1],
         recipe_level: [1,5],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     });
 
     smelting_recipes.items["Low quality iron ingot"] = new ItemRecipe({
@@ -908,34 +926,34 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         recipe_skill: "Smelting",
     });
 
-    crafting_recipes.items["Processed rough wood"] = new ItemRecipe({
+    woodworking_recipes.items["Processed rough wood"] = new ItemRecipe({
         name: "Processed rough wood",
         recipe_type: "material",
         materials: [{material_id: "Piece of rough wood", count: 5}], 
         result: {result_id: "Processed rough wood", count: 1},
         success_chance: [0.6,1],
         recipe_level: [1,5],
-        recipe_skill: "Crafting",
+        recipe_skill: "Woodworking",
     });
-    crafting_recipes.items["Processed wood"] = new ItemRecipe({
+    woodworking_recipes.items["Processed wood"] = new ItemRecipe({
         name: "Processed wood",
         recipe_type: "material",
         materials: [{material_id: "Piece of wood", count: 5}], 
         result: {result_id: "Processed wood", count: 1},
         success_chance: [0.4,1],
         recipe_level: [5,15],
-        recipe_skill: "Crafting",
+        recipe_skill: "Woodworking",
     });
-    crafting_recipes.items["Processed ash wood"] = new ItemRecipe({
+    woodworking_recipes.items["Processed ash wood"] = new ItemRecipe({
         name: "Processed ash wood",
         recipe_type: "material",
         materials: [{material_id: "Piece of ash wood", count: 5}], 
         result: {result_id: "Processed ash wood", count: 1},
         success_chance: [0.4,1],
         recipe_level: [10,20],
-        recipe_skill: "Crafting",
+        recipe_skill: "Woodworking",
     });
-    crafting_recipes.items["Processed weak monster bone"] = new ItemRecipe({
+    butchering_recipes.items["Processed weak monster bone"] = new ItemRecipe({
         name: "Processed weak monster bone",
         is_unlocked: false,
         recipe_type: "material",
@@ -943,7 +961,7 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         result: {result_id: "Processed weak monster bone", count: 1},
         success_chance: [0.1,1],
         recipe_level: [10,20],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     });
     smelting_recipes.items["Charcoal"] = new ItemRecipe({
         name: "Charcoal",
@@ -965,35 +983,32 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         recipe_skill: "Cooking",
     });
 
-    crafting_recipes.items["High quality wolf fang"] = new ItemRecipe({
+    butchering_recipes.items["High quality wolf fang"] = new ItemRecipe({
         name: "High quality wolf fang",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Wolf fang", count: 50}],
         result: {result_id: "High quality wolf fang", count: 1},
         success_chance: [0.5,1],
         recipe_level: [1,7],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     });
-    crafting_recipes.items["High quality boar tusk"] = new ItemRecipe({
+    butchering_recipes.items["High quality boar tusk"] = new ItemRecipe({
         name: "High quality boar tusk",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Boar tusk", count: 50}], 
         result: {result_id: "High quality boar tusk", count: 1},
         success_chance: [0.5,1],
         recipe_level: [5,12],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     }); 
-    crafting_recipes.items["Pristine mountain goat horn"] = new ItemRecipe({
+    butchering_recipes.items["Pristine mountain goat horn"] = new ItemRecipe({
         name: "Pristine mountain goat horn",
-        is_unlocked: false,
         recipe_type: "material",
         materials: [{material_id: "Mountain goat horn", count: 50}], 
         result: {result_id: "Pristine mountain goat horn", count: 1},
         success_chance: [0.5,1],
         recipe_level: [10,17],
-        recipe_skill: "Crafting",
+        recipe_skill: "Butchering",
     }); 
 
     alchemy_recipes.items["Potash"] = new ItemRecipe({
@@ -1146,7 +1161,9 @@ const recipes = {
     cooking: cooking_recipes, 
     smelting: smelting_recipes, 
     forging: forging_recipes, 
-    alchemy: alchemy_recipes
+    alchemy: alchemy_recipes,
+    butchering: butchering_recipes,
+    woodworking: woodworking_recipes,
 }
 
 export { recipes, get_recipe_xp_value, get_crafting_quality_caps, ItemRecipe }

--- a/src/enemies.js
+++ b/src/enemies.js
@@ -1,5 +1,8 @@
 "use strict";
 
+import { skills } from "./skills.js"
+import { get_total_skill_coefficient } from "./character.js";
+
 let enemy_templates = {};
 let enemy_killcount = {};
 //enemy templates; locations create new enemies based on them
@@ -72,8 +75,13 @@ class Enemy {
      * @param {*} drop_chance_modifier 
      * @returns 
      */
-    get_droprate_modifier(drop_chance_modifier) {
+    get_droprate_modifier(drop_chance_modifier = 1) {
         let droprate_modifier = 1 * drop_chance_modifier;
+
+        if (this.tags["beast"]) {
+            droprate_modifier *= get_total_skill_coefficient({ skill_id: "Butchering", scaling_type: "multiplicative" });
+        }
+
         return droprate_modifier;
     }
 }

--- a/src/items.js
+++ b/src/items.js
@@ -222,7 +222,6 @@ class OtherItem extends Item {
     constructor(item_data) {
         super(item_data);
         this.item_type = "OTHER";
-        this.stackable = true;
     }
 }
 
@@ -239,7 +238,6 @@ class ItemComponent extends Item {
     constructor(item_data) {
         super(item_data);
         this.item_type = "COMPONENT";
-        this.stackable = false;
         this.component_tier = item_data.component_tier || 1;
         this.component_stats = item_data.component_stats || {};
         this.tags["component"] = true;
@@ -371,7 +369,6 @@ class UsableItem extends Item {
     constructor(item_data) {
         super(item_data);
         this.item_type = "USABLE";
-        this.stackable = true;
         this.effects = item_data.effects || {};
         this.recovery_chances = item_data.recovery_chances || {};
         this.saturates_market = false;
@@ -384,7 +381,6 @@ class Equippable extends Item {
     constructor(item_data) {
         super(item_data);
         this.item_type = "EQUIPPABLE";
-        this.stackable = false;
         this.bonus_skill_levels = item_data.bonus_skill_levels || {};
 
         this.quality = Math.round(Number(item_data.quality)) || 100;
@@ -680,6 +676,7 @@ class Armor extends Equippable {
             return this.calculateDefense(quality);
         }
     }
+
     calculateDefense(quality) {
         if(this.components) {
             return Math.ceil(((item_templates[this.components.internal].defense_value || item_templates[this.components.internal].base_defense ||0) + 
@@ -860,7 +857,6 @@ const book_stats = {};
 class Book extends Item {
     constructor(item_data) {
         super(item_data);
-        this.stackable = true;
         this.item_type = "BOOK";
         this.name = item_data.name;
 
@@ -1056,18 +1052,9 @@ book_stats["Butchering and you"] = new BookData({
     required_time: 240,
     literacy_xp_rate: 2,
     rewards: {
+        skills: ["Butchering"],
         recipes: [
-            {category: "crafting", subcategory: "items", recipe_id: "Piece of wolf leather"},
-            {category: "crafting", subcategory: "items", recipe_id: "Piece of boar leather"},
-            {category: "crafting", subcategory: "items", recipe_id: "Piece of goat leather"},
-            {category: "crafting", subcategory: "items", recipe_id: "Processed wolf pelt"},
-            {category: "crafting", subcategory: "items", recipe_id: "Processed boar hide"},
-            {category: "crafting", subcategory: "items", recipe_id: "Processed goat hide"},
-            {category: "cooking", subcategory: "items", recipe_id: "Animal fat"},
-            {category: "crafting", subcategory: "items", recipe_id: "High quality wolf fang"},
-            {category: "crafting", subcategory: "items", recipe_id: "High quality boar tusk"},
-            {category: "crafting", subcategory: "items", recipe_id: "Pristine mountain goat horn"},
-            {category: "crafting", subcategory: "items", recipe_id: "Processed weak monster bone"},
+            {category: "cooking", subcategory: "items", recipe_id: "Animal fat"}
         ],
     },
 });

--- a/src/locations.js
+++ b/src/locations.js
@@ -78,6 +78,8 @@ class Location {
                 smelting: Number,
                 cooking: Number,
                 alchemy: Number,
+                butchering: Number,
+                woodworking: Number,
             }
         },
          */
@@ -939,6 +941,8 @@ function get_location_type_penalty(type, stage, stat, category) {
                 smelting: 1,
                 cooking: 1,
                 alchemy: 1,
+                butchering: 1,
+                woodworking: 1,
             }
         },
     });

--- a/src/main.js
+++ b/src/main.js
@@ -3044,21 +3044,6 @@ function load(save_data) {
         });
     }
 
-    Object.keys(save_data.skills).forEach(key => { 
-        if(key === "Literacy") {
-            return; //done separately, for compatibility with older saves (can be eventually removed)
-        }
-        if(skills[key] && !skills[key].is_parent){
-            if(save_data.skills[key].total_xp > 0) {
-                add_xp_to_skill({skill: skills[key], xp_to_add: save_data.skills[key].total_xp, 
-                                    should_info: false, add_to_parent: true, use_bonus: false, cap_gained_xp: false,
-                                });
-            }
-        } else if(save_data.skills[key].total_xp > 0) {
-                console.warn(`Skill "${key}" couldn't be found!`);
-        }
-    }); //add xp to skills
-
     if(save_data.books) {
         let total_book_xp = 0;
         const literacy_xp = save_data.skills["Literacy"].total_xp;
@@ -3089,6 +3074,21 @@ function load(save_data) {
             add_xp_to_skill({skill: skills["Literacy"], should_info: false, xp_to_add: literacy_xp, use_bonus: false, cap_gained_xp: false});
         }
     }
+    
+    Object.keys(save_data.skills).forEach(key => { 
+        if(key === "Literacy") {
+            return; //done separately, for compatibility with older saves (can be eventually removed)
+        }
+        if(skills[key] && !skills[key].is_parent){
+            if(save_data.skills[key].total_xp > 0) {
+                add_xp_to_skill({skill: skills[key], xp_to_add: save_data.skills[key].total_xp, 
+                                    should_info: false, add_to_parent: true, use_bonus: false, cap_gained_xp: false,
+                                });
+            }
+        } else if(save_data.skills[key].total_xp > 0) {
+                console.warn(`Skill "${key}" couldn't be found!`);
+        }
+    }); //add xp to skills
 
     if(save_data["stances"]) {
         Object.keys(save_data["stances"]).forEach(stance => {

--- a/src/skills.js
+++ b/src/skills.js
@@ -2003,6 +2003,29 @@ Multiplies AP with daggers by ${Math.round((get_total_skill_coefficient({skill_i
         xp_scaling: 1.5,
         max_level: 60,
     });
+    skills["Butchering"] = new Skill({
+        skill_id: "Butchering", 
+        names: {0: "Butchering"}, 
+        description: "Making the most of what you kill",
+        category: skill_category_crafting,
+        base_xp_cost: 40,
+        xp_scaling: 1.5,
+        max_level_coefficient: 2,
+        max_level: 60,
+        is_unlocked: false,
+        get_effect_description: () => {
+            let value = get_total_skill_coefficient({skill_id:"Butchering",scaling_type:"multiplicative"});
+            return `Multiplies drop chances from Beasts by ${Math.round(value*100)/100}`;},
+    });
+    skills["Woodworking"] = new Skill({
+        skill_id: "Woodworking", 
+        names: {0: "Woodworking"}, 
+        description: "Turning wood logs into something useful",
+        category: skill_category_crafting,
+        base_xp_cost: 40,
+        xp_scaling: 1.5,
+        max_level: 60,
+    });
 })();
 
 //defensive skills

--- a/style.css
+++ b/style.css
@@ -927,12 +927,11 @@ input[type=checkbox], input[type=radio] {
 			padding: 3px;
 			padding-left: 2.4px;
 			padding-right: 2.4px;
-			min-width: 63px;
-			max-width: fit-content;
 			text-align: center;
 			outline: 1px solid white;
 			margin: 1px;
 			cursor: pointer;
+			flex-grow: 1;
 		}
 
 	.crafting_subpage_buttons {
@@ -949,7 +948,7 @@ input[type=checkbox], input[type=radio] {
 		}
 
 .crafting_recipe_list {
-	height: 333px;
+	height: 305px;
 	width:100%;
 	top: 60px;
 	overflow-y: scroll;


### PR DESCRIPTION
- Added 2 new crafting skills: Butchering and Woodworking, with relevant recipes moves over from Crafting.
- Changed the effects of the butchering book from adding recipes to unlocking the Butchering skill itself.
- In addition to being a crafting skill, Butchering has a new type of effect on it...

notes: I had to swap the order of parsing book rewards and setting skill xp during loading, to prevent Butchering xp getting reset due to its unlock status not being set early enough. Didn't seem to break anything, but its something to look out for.

Might be unnecessary and overstepping a bit, but I removed the unused "stackable" property on items for code clarity.