### PR TITLE
Fishing 1.5

### DIFF
--- a/src/active_effects.js
+++ b/src/active_effects.js
@@ -144,6 +144,15 @@ class ActiveEffect {
         },
         tags: {"buff": true, "medicine": true},
     });
+    effect_templates["Potent healing powder"] = new ActiveEffect({
+        name: "Potent healing powder",
+        effects: {
+            stats: {
+                health_regeneration_flat: {flat: 9},
+            }
+        },
+        tags: {"buff": true, "medicine": true},
+    });
     effect_templates["Weak healing potion"] = new ActiveEffect({
         name: "Weak healing potion",
         effects: {
@@ -164,12 +173,32 @@ class ActiveEffect {
         },
         tags: {"buff": true, "medicine": true},
     });
+    effect_templates["Potent healing potion"] = new ActiveEffect({
+        name: "Potent healing potion",
+        effects: {
+            stats: {
+                health_regeneration_flat: {flat: 36},
+                health_regeneration_percent: {flat: 3},
+            }
+        },
+        tags: {"buff": true, "medicine": true},
+    });
     effect_templates["Weak healing balm"] = new ActiveEffect({
         name: "Weak healing balm",
         effects: {
             stats: {
                 health_regeneration_flat: {flat: 5},
                 health_regeneration_percent: {flat: 0.5},
+            }
+        },
+        tags: {"buff": true, "medicine": true},
+    });
+    effect_templates["Healing balm"] = new ActiveEffect({
+        name: "Healing balm",
+        effects: {
+            stats: {
+                health_regeneration_flat: {flat: 12},
+                health_regeneration_percent: {flat: 1},
             }
         },
         tags: {"buff": true, "medicine": true},
@@ -210,6 +239,16 @@ class ActiveEffect {
             stats: {
                 stamina_regeneration_flat: {flat: 2},
                 health_regeneration_flat: {flat: 2},
+            }
+        },
+        tags: {"buff": true, "food": true},
+    });
+    effect_templates["Tasty meat meal"] = new ActiveEffect({
+        name: "Tasty meat meal",
+        effects: {
+            stats: {
+                stamina_regeneration_flat: {flat: 3},
+                health_regeneration_flat: {flat: 3},
             }
         },
         tags: {"buff": true, "food": true},

--- a/src/character.js
+++ b/src/character.js
@@ -80,27 +80,39 @@ class Hero extends InventoryHaver {
                 this.name = "Hero";
                 this.titles = {};
                 this.stats = {
-                        full: {...this.base_stats}, 
-                        total_flat: {},
-                        total_multiplier: {},
-                        flat: {
-                                level: {},
-                                skills: {},
-                                equipment: {},
-                                skill_milestones: {},
-                                books: {},
-                                light_level: {},
-                                environment: {},
-                        },
-                        multiplier: {
-                                skills: {},
-                                skill_milestones: {},
-                                equipment: {},
-                                books: {},
-                                stance: {},
-                                light_level: {},
-                                environment: {},
-                        }
+                    full: {...this.base_stats}, 
+                    total_flat: {},
+                    total_multiplier: {},
+                    flat: {
+                            level: {},
+                            skills: {},
+                            equipment: {},
+                            skill_milestones: {},
+                            books: {},
+                            light_level: {},
+                            environment: {},
+                    },
+                    multiplier: {
+                            skills: {},
+                            skill_milestones: {},
+                            equipment: {},
+                            books: {},
+                            stance: {},
+                            light_level: {},
+                            environment: {},
+                    },
+                    get_health_regeneration_total() {
+                        return this.full.health_regeneration_flat + (this.full.max_health * this.full.health_regeneration_percent / 100);
+                    },
+                    get_health_loss_total() {
+                        return this.full.health_loss_flat + (this.full.max_health * this.full.health_loss_percent / 100);
+                    },
+                    get_stamina_regeneration_total() {
+                        return this.full.stamina_regeneration_flat + (this.full.max_stamina * this.full.stamina_regeneration_percent / 100);
+                    },
+                    get_mana_regeneration_total() {
+                        return this.full.mana_regeneration_flat + (this.full.max_mana * this.full.mana_regeneration_percent / 100);
+                    },
                 };
                 this.reputation = { //effects would go up to 1000?
                         Village: 0,

--- a/src/crafting_recipes.js
+++ b/src/crafting_recipes.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import { character, get_total_skill_level } from "./character.js";
-import { Armor, ArmorComponent, Cape, Shield, ShieldComponent, Weapon, WeaponComponent, item_templates } from "./items.js";
+import { Armor, ArmorComponent, Cape, Shield, ShieldComponent, Weapon, WeaponComponent, Amulet, item_templates } from "./items.js";
 import { skills } from "./skills.js";
 import { clamp, random_range } from "./misc.js";
 
@@ -145,9 +145,12 @@ class ComponentRecipe extends ItemRecipe{
             } else if(result.tags["weapon component"]) {
 
                 return new WeaponComponent({...item_templates[result.id], quality: quality});
-            } else if(result.tags["shield component"]) {
+            } else if (result.tags["shield component"]) {
 
-                return new ShieldComponent({...item_templates[result.id], quality: quality});
+                return new ShieldComponent({ ...item_templates[result.id], quality: quality });
+            } else if (result.tags["amulet"]) {
+
+                return new Amulet({ ...item_templates[result.id], quality: quality });
             } else {
                 throw new Error(`Component recipe ${this.name} does not produce a valid result!`);
             }
@@ -823,7 +826,15 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         component_type: "shoes interior",
         recipe_skill: "Crafting",
     });
-    
+
+    crafting_recipes.equipment["Amulet"] = new ComponentRecipe({
+        name: "Amulet",
+        materials: [
+            {material_id: "Wool cloth", count: 5, result_id: "Wool scarf"}
+        ],
+        item_type: "Amulet",
+        recipe_skill: "Crafting",
+    });
 })();
 
 //componentless equipment (currently just capes)
@@ -1232,6 +1243,15 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         recipe_level: [5,15],
         recipe_skill: "Crafting",
     });
+    crafting_recipes.items["Flax string"] = new ItemRecipe({
+        name: "Flax string",
+        recipe_type: "material",
+        materials: [{material_id: "Flax", count: 5}], 
+        result: {result_id: "Flax string", count: 1},
+        success_chance: [0.2,1],
+        recipe_level: [20,30],
+        recipe_skill: "Crafting",
+    });
 
     butchering_recipes.items["High quality wolf fang"] = new ItemRecipe({
         name: "High quality wolf fang",
@@ -1345,6 +1365,34 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         recipe_level: [12, 22],
         recipe_skill: "Woodworking",
     });
+    woodworking_recipes.items["Hickory wood fishing pole"] = new ItemRecipe({
+        name: "Hickory wood fishing pole",
+        recipe_type: "equipment",
+        materials: [
+            { material_id: "Processed hickory wood", count: 4 },
+            //{ material_id: "Simple long wooden shaft", count: 1 },    //TODO
+            { material_id: "Flax string", count: 1 },
+            { material_id: "Metal fishing hook", count: 1 },
+        ],
+        result: { result_id: "Hickory wood fishing pole", count: 1 },
+        success_chance: [0.1, 1],
+        recipe_level: [17, 27],
+        recipe_skill: "Woodworking",
+    });
+    woodworking_recipes.items["Alchemical wood fishing pole"] = new ItemRecipe({
+        name: "Alchemical wood fishing pole",
+        recipe_type: "equipment",
+        materials: [
+            { material_id: "Alchemical Wood", count: 4 },
+            //{ material_id: "Simple long wooden shaft", count: 1 },    //TODO
+            { material_id: "Flax string", count: 1 },
+            { material_id: "Metal fishing hook", count: 1 },
+        ],
+        result: { result_id: "Alchemical wood fishing pole", count: 1 },
+        success_chance: [0.1, 1],
+        recipe_level: [22, 32],
+        recipe_skill: "Woodworking",
+    });
 })();
 
 //consumables
@@ -1404,7 +1452,7 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
                     { material_id: "Cooking herbs", count: 2}], 
         result: {result_id: "Goat stew", count: 1},
         success_chance: [0.4,1],
-        recipe_level: [15,25],
+        recipe_level: [12,22],
         recipe_skill: "Cooking",
     });
     cooking_recipes.items["Bread kwas"] = new ItemRecipe({
@@ -1596,6 +1644,16 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         recipe_level: [5,15],
         recipe_skill: "Alchemy",
     });
+    alchemy_recipes.items["Potent healing powder"] = new ItemRecipe({
+        name: "Potent healing powder",
+        recipe_type: "usable",
+        is_unlocked: false,
+        materials: [{material_id: "Willow bark", count: 3}, {material_id: "Silver thistle", count: 3}],
+        result: {result_id: "Potent healing powder", count: 1},
+        success_chance: [0.1,1],
+        recipe_level: [10,20],
+        recipe_skill: "Alchemy",
+    });
     alchemy_recipes.items["Oneberry juice"] = new ItemRecipe({
         name: "Oneberry juice",
         recipe_type: "usable",
@@ -1632,6 +1690,18 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         result: {result_id: "Healing balm", count: 1},
         success_chance: [0.1,1],
         recipe_level: [7,15],
+        recipe_skill: "Alchemy",
+    });
+    alchemy_recipes.items["Thick healing balm"] = new ItemRecipe({
+        name: "Thick healing balm",
+        recipe_type: "usable",
+        is_unlocked: false,
+        materials: [{material_id: "Healing balm", count: 1},
+                    {material_id: "Willow bark", count: 2},
+        ],
+        result: {result_id: "Thick healing balm", count: 2},
+        success_chance: [0.1,1],
+        recipe_level: [12,20],
         recipe_skill: "Alchemy",
     });
 
@@ -1720,16 +1790,6 @@ function get_recipe_xp_value({category, subcategory, recipe_id, material_count, 
         success_chance: [0.1,1],
         recipe_skill: "Crafting",
         recipe_level: [10,20],
-    });
-
-    crafting_recipes.items["Wool scarf"] = new ItemRecipe({
-        name: "Wool scarf",
-        recipe_type: "equipment",
-        materials: [{material_id: "Wool cloth", count: 5}], 
-        result: {result_id: "Wool scarf", count: 1},
-        success_chance: [0.1,1],
-        recipe_skill: "Crafting",
-        recipe_level: [5,15],
     });
 })();
 

--- a/src/display.js
+++ b/src/display.js
@@ -347,6 +347,10 @@ function create_item_tooltip(item, options = {}, is_trade = false) {
     return item_tooltip;
 }
 
+function round(number) {
+    return +number.toFixed(1);
+}
+
 /**
  * @param {Object} params
  * @param {Item} params.item
@@ -367,34 +371,32 @@ function create_item_tooltip_content({item, options={}, is_trade = false}) {
         item_tooltip += `<br>${item.description}`; 
     }
 
+    let show_quality = item.quality && !options.skip_quality && item.use_quality;
     let quality = item.quality;
+    if (show_quality && options?.quality && options.quality[0]) {
+        quality = options.quality[0];
+    }
+
+    if(show_quality) {
+        if(options?.quality?.length == 2) {
+            const outline_class_1 = rarity_outlines[item.getRarity(options.quality[0])];
+            const outline_class_2 = rarity_outlines[item.getRarity(options.quality[1])];
+                
+            item_tooltip += `<br><br><b>Quality: <span class="${outline_class_1}" style="color: ${rarity_colors[item.getRarity(options.quality[0])]}"> ${options.quality[0]}% </span> - <span class="${outline_class_2}" style="color: ${rarity_colors[item.getRarity(options.quality[1])]}"> ${options.quality[1]}% </span>`;
+            item_tooltip += `<br>[<span class="${outline_class_1}" style="color: ${rarity_colors[item.getRarity(options.quality[0])]}">${item.getRarity(options.quality[0])}</span>-<span class="${outline_class_2}" style="color: ${rarity_colors[item.getRarity(options.quality[1])]}">${item.getRarity(options.quality[1])}</span>] </b>`;
+        } else {
+            const outline_class = rarity_outlines[item.getRarity(quality)];
+                
+            item_tooltip += `<br><br><b class="${outline_class}" style="color: ${rarity_colors[item.getRarity(quality)]}">Quality: ${quality}% [${item.getRarity(quality)}]</b>`;
+        }
+    }
+    if(item.tags.unique) {
+        item_tooltip += `<br><b class="item_unique outline_white">Unique</b>`;
+    }
 
     //add stats if can be equipped
-    if(item.item_type === "EQUIPPABLE"){ 
-        if(options?.quality && options.quality[0]) {
-            quality = options.quality[0];
-        }
-
-        if(!item.ignore_quality) {
-            if(!options.skip_quality && options?.quality?.length == 2) {
-                const outline_class_1 = rarity_outlines[item.getRarity(options.quality[0])];
-                const outline_class_2 = rarity_outlines[item.getRarity(options.quality[1])];
-                
-                item_tooltip += `<br><br><b>Quality: <span class="${outline_class_1}" style="color: ${rarity_colors[item.getRarity(options.quality[0])]}"> ${options.quality[0]}% </span> - <span class="${outline_class_2}" style="color: ${rarity_colors[item.getRarity(options.quality[1])]}"> ${options.quality[1]}% </span>`;
-                item_tooltip += `<br>[<span class="${outline_class_1}" style="color: ${rarity_colors[item.getRarity(options.quality[0])]}">${item.getRarity(options.quality[0])}</span>-<span class="${outline_class_2}" style="color: ${rarity_colors[item.getRarity(options.quality[1])]}">${item.getRarity(options.quality[1])}</span>] </b>`;
-            } else {
-                const outline_class = rarity_outlines[item.getRarity(quality)];
-                
-                item_tooltip += `<br><br><b class="${outline_class}" style="color: ${rarity_colors[item.getRarity(quality)]}">Quality: ${quality}% [${item.getRarity(quality)}]</b>`;
-            }
-        }
-
-        if(item.tags.unique) {
-            item_tooltip += `<br><br><b class="item_unique outline_white">Unique</b>`;
-        }
-
-
-        item_tooltip += `<br><br>Slot: <b>${item.equip_slot}</b>`;
+    if(item.item_type === "EQUIPPABLE") { 
+        item_tooltip += `<br>Slot: <b>${item.equip_slot}</b>`;
         if(item.equip_slot === "weapon") {
             item_tooltip += `<br>Type: <b>${item.weapon_type}</b>`;
         }
@@ -403,7 +405,8 @@ function create_item_tooltip_content({item, options={}, is_trade = false}) {
             let component_description = `<br><br><span class="item_component_list">`;
             const components = Object.keys(item.components);
 
-            if(item.components) {
+            if (item.components) {
+                //TODO future proof by looping through all components, not just static 2
                 component_description += `[${item_templates[item.components[components[0]]].name}]`;
                 if(!item.components[components[1]]) {
                     component_description += `<br>+<br>no [${components[1]}]`;
@@ -416,21 +419,17 @@ function create_item_tooltip_content({item, options={}, is_trade = false}) {
             item_tooltip += component_description;
         }
 
-        if(!options.skip_quality && options?.quality?.length == 2) {
+        if(show_quality && options?.quality?.length == 2) {
             if(item.getAttack) {
                 item_tooltip += 
-                    `<br><br>Attack: ${Math.round(10*item.getAttack(options.quality[0]), true)/10} - ${Math.round(10*item.getAttack(options.quality[1], true))/10}`;
+                    `<br><br>Attack: ${round(item.getAttack(options.quality[0]))} - ${round(item.getAttack(options.quality[1]))}`;
             } else if(item.getDefense) { 
                 item_tooltip += 
-                `<br><br>Defense: ${Math.round(10*item.getDefense(options.quality[0]))/10} - ${Math.round(10*item.getDefense(options.quality[1]))/10}`;
-            } else if(item.offhand_type === "shield") {
-                if(item.tags.ignore_skill) {
-                    item_tooltip += 
-                `<br><br>Can block up to: ${Math.round(10*item.getShieldStrength(options.quality[0]))/10} - ${Math.round(10*item.getShieldStrength(options.quality[1]))/10} damage [base: ${item.getShieldStrength(options.quality[0])}-${item.getShieldStrength(options.quality[1])}]`;
-                } else {
-                    item_tooltip += 
-                `<br><br>Can block up to: ${Math.round(10*item.getShieldStrength(options.quality[0])*(character.stats.total_multiplier.block_strength))/10} - ${Math.round(10*item.getShieldStrength(options.quality[1])*(character.stats.total_multiplier.block_strength))/10} damage [base: ${item.getShieldStrength(options.quality[0])}-${item.getShieldStrength(options.quality[1])}]`;
-                }
+                    `<br><br>Defense: ${round(item.getDefense(options.quality[0]))} - ${round(item.getDefense(options.quality[1]))}`;
+            } else if (item.offhand_type === "shield") {
+                const block_multiplier = item.tags.ignore_skill ? character.stats.total_multiplier.block_strength : 1;
+                item_tooltip += 
+                    `<br><br>Can block up to: ${round(item.getShieldStrength(options.quality[0])*block_multiplier)} - ${round(item.getShieldStrength(options.quality[1])*block_multiplier)} damage [base: ${item.getShieldStrength(options.quality[0])}-${item.getShieldStrength(options.quality[1])}]`;
             }
 
             const equip_stats_0 = item.getStats(options.quality[0]);
@@ -472,14 +471,14 @@ function create_item_tooltip_content({item, options={}, is_trade = false}) {
             Object.keys(equip_stats).forEach(function(effect_key) {
 
                 if(equip_stats[effect_key].flat != null) {
-                    item_tooltip += 
+                        item_tooltip +=
                     `<br>${capitalize_first_letter(effect_key).replace("_"," ")}: +${equip_stats[effect_key].flat}`;
-                }
+                    }
                 if(equip_stats[effect_key].multiplier != null) {
-                    item_tooltip += 
+                        item_tooltip +=
                     `<br>${capitalize_first_letter(effect_key).replace("_"," ")}: x${equip_stats[effect_key].multiplier}`;
-                }
-            });
+                    }
+                });
         }
         const equip_bonus_skill_levels = item.getBonusSkillLevels();
         if(Object.keys(equip_bonus_skill_levels).length > 0) {
@@ -489,61 +488,12 @@ function create_item_tooltip_content({item, options={}, is_trade = false}) {
             if(skill_key.includes("category_")) {
                 item_tooltip +=  `<br>${skill_key} skills level: +${equip_bonus_skill_levels[skill_key]}`;
             } else {
-                item_tooltip +=  `<br>${skills[skill_key].name()} level: +${equip_bonus_skill_levels[skill_key]}`;
+                item_tooltip += `<br>${skills[skill_key].name()} level: +${equip_bonus_skill_levels[skill_key]}`;
             }
         });
+    }
 
-        item_tooltip += "<br>";
-    } else if (item.item_type === "USABLE") {
-        item_tooltip += `<br>`;
-
-        if(item.effects.length > 0) {
-            item_tooltip += "<br>Effects: "
-        }
-        for(let i = 0; i < item.effects.length; i++) {
-            item_tooltip += create_effect_tooltip({effect_name: item.effects[i].effect, duration: item.effects[i].duration, add_bonus: true}).outerHTML;
-        }
-    } else if(item.item_type === "BOOK") {
-        if(!book_stats[item.name].is_finished) {
-            item_tooltip += `<br><br>Time to read: ${item.getRemainingTime()} minutes`;
-        }
-        else {
-            item_tooltip += `<br><br>Reading it provided ${character.name} with:`;
-            if(Object.keys(book_stats[item.name].bonuses).length > 0) {
-                item_tooltip += `<br>- ${format_book_bonuses(book_stats[item.name].bonuses)}`;
-            }
-            if(book_stats[item.name].rewards?.skills) {
-                if(book_stats[item.name].rewards.skills.length == 1) {
-                    item_tooltip += `<br>- a new skill`;
-                } else {
-                    item_tooltip += `<br>- new skills`;
-                }
-            }
-            if(book_stats[item.name].rewards?.recipes) {
-                if(book_stats[item.name].rewards.recipes.length == 1) {
-                    item_tooltip += `<br>- a new recipe`;
-                } else {
-                    item_tooltip += `<br>- new recipes`;
-                }
-            }
-        }
-        item_tooltip += "<br>";
-    } else if(item.tags.component) {
-        if(options?.quality && options.quality[0]) {
-            quality = options.quality[0];
-        }
-
-        if(!options.skip_quality && options?.quality?.length == 2) {
-            const outline_class_1 = rarity_outlines[item.getRarity(options.quality[0])];
-            const outline_class_2 = rarity_outlines[item.getRarity(options.quality[1])];
-            
-            item_tooltip += `<br><br><b>Quality: <span class="${outline_class_1}" style="color: ${rarity_colors[item.getRarity(options.quality[0])]}"> ${options.quality[0]}% </span> - <span class="${outline_class_2}" style="color: ${rarity_colors[item.getRarity(options.quality[1])]}"> ${options.quality[1]}% </span>`;
-            item_tooltip += `<br>[<span class="${outline_class_1}" style="color: ${rarity_colors[item.getRarity(options.quality[0])]}"> ${item.getRarity(options.quality[0])}</span> - <span class="${outline_class_2}" style="color: ${rarity_colors[item.getRarity(options.quality[1])]}"> ${item.getRarity(options.quality[1])}</span>]</b>`;
-        } else {
-            let outline_class = rarity_outlines[item.getRarity(quality)];
-            
-            item_tooltip += `<br><br><b class="${outline_class}" style="color: ${rarity_colors[item.getRarity(quality)]}">Quality: ${quality}% [${item.getRarity(quality)}]</b>`;
-        }
+    if (item.component_stats) {
         if(item.component_tier) {
             item_tooltip += `<br><br>Component tier: ${item.component_tier}`;
         }
@@ -570,23 +520,59 @@ function create_item_tooltip_content({item, options={}, is_trade = false}) {
                 `<br>${capitalize_first_letter(effect_key).replace("_"," ")}: x${item.component_stats[effect_key].multiplier}`;
             }
         });
-        item_tooltip += "<br>";
-    } else {
-        item_tooltip += "<br>";
     }
+
+    if(item?.base_size) {
+        item_tooltip += `<br><br>Size: ${item.getSize()}cm`;
+    }
+
+    if (item.effects?.length > 0) {
+        item_tooltip += "<br><br>Effects: "
+
+        for (let i = 0; i < item.effects.length; i++) {
+            item_tooltip += create_effect_tooltip({ effect_name: item.effects[i].effect, duration: item.effects[i].duration, add_bonus: true }).outerHTML;
+        }
+    }
+
+    if (item.item_type === "BOOK") {
+        if(!book_stats[item.name].is_finished) {
+            item_tooltip += `<br><br>Time to read: ${item.getRemainingTime()} minutes`;
+        }
+        else {
+            item_tooltip += `<br><br>Reading it provided ${character.name} with:`;
+            if(Object.keys(book_stats[item.name].bonuses).length > 0) {
+                item_tooltip += `<br>- ${format_book_bonuses(book_stats[item.name].bonuses)}`;
+            }
+            if(book_stats[item.name].rewards?.skills) {
+                if(book_stats[item.name].rewards.skills.length == 1) {
+                    item_tooltip += `<br>- a new skill`;
+                } else {
+                    item_tooltip += `<br>- new skills`;
+                }
+            }
+            if(book_stats[item.name].rewards?.recipes) {
+                if(book_stats[item.name].rewards.recipes.length == 1) {
+                    item_tooltip += `<br>- a new recipe`;
+                } else {
+                    item_tooltip += `<br>- new recipes`;
+                }
+            }
+        }
+    }
+
     if(item.material_type) {
-        item_tooltip += `<br>Material type: ${item.material_type}<br>`;
+        item_tooltip += `<br><br>Material type: ${item.material_type}`;
     }
 
     if(!item.tags.unique) {
         if(!options.skip_quality && options?.quality?.length == 2) { 
             //ignore quality, instead use quality passed as param
-            item_tooltip += `<br>Value: ${format_money(
+            item_tooltip += `<br><br>Value: ${format_money(
             round_item_price(
                 item[value_function]({quality:options.quality[0], region:current_location?.market_region})))} - ${format_money(round_item_price(item.getBaseValue({quality:options.quality[1]})
             ))}`;
         } else {
-            item_tooltip += `<br>Value: ${format_money(round_item_price(item[value_function]({quality, region:current_location?.market_region, multiplier: ((options && options.trader) ? traders[current_trader].getProfitMargin(current_location.market_region) : 1)})))}`;
+            item_tooltip += `<br><br>Value: ${format_money(round_item_price(item[value_function]({quality, region:current_location?.market_region, multiplier: ((options && options.trader) ? traders[current_trader].getProfitMargin(current_location.market_region) : 1)})))}`;
             if(item.saturates_market) {
                 item_tooltip += ` [originally ${format_money(round_item_price(item.getBaseValue({quality, region:current_location?.market_region}) * ((options && options.trader) ? traders[current_trader].getProfitMargin(current_location.market_region) : 1) || 1))}]`
             }
@@ -1252,6 +1238,9 @@ function sort_displayed_inventory({sort_by, target = "character", change_directi
                 if (item_template_a.component_tier != item_template_b.component_tier) { 
                     return item_template_a.component_tier > item_template_b.component_tier ? plus : minus;
                 }
+                if (item_template_a.item_tier != item_template_b.item_tier) { 
+                    return item_template_a.item_tier > item_template_b.item_tier ? plus : minus;
+                }
             }
 
             //...otherwise, fall back to sorting by name
@@ -1744,7 +1733,7 @@ function create_inventory_item_div({key, item_count, target, is_equipped, trade_
         }
     }
 
-    if("quality" in target_item) {
+    if(target_item.use_quality) {
         item_control_div.dataset.item_quality = target_item.quality;
     }
 
@@ -1795,7 +1784,11 @@ function create_inventory_item_div({key, item_count, target, is_equipped, trade_
         //
         item_name_div_content = `<span class = "item_category"></span> <span class = "item_name">${target_item.getName()}</span>`;
     }
-    
+
+    if (target_item.use_quality && target_item.quality) {
+        item_name_div_content += ` [<b class="${rarity_outlines[target_item.getRarity()]}" style="color: ${ rarity_colors[target_item.getRarity()] } ">${target_item.quality}%</b>]`;
+    }
+
     if(item_count > 1) {
         item_name_div_content += `<span class="item_count"> x${item_count}</span>`;
     } else {
@@ -3191,10 +3184,11 @@ function create_recipe_tooltip_content({category, subcategory, recipe_id, materi
             tooltip += `<span style="color:red"><b>${name} x${character.inventory[item_templates[material.material_id].getInventoryKey()]?.count || 0}/${material.count}</b></span><br>`;
         }
 
-        const quality_range = recipe.get_quality_range(station_tier - item_templates[material.result_id].component_tier);
+        const result_tier = item_templates[material.result_id].component_tier ?? item_templates[material.result_id].item_tier;
+        const quality_range = recipe.get_quality_range(station_tier - result_tier);
 
-        const xp_val_1 = get_recipe_xp_value({category, subcategory, recipe_id, material_count: material.count, result_tier: item_templates[material.result_id].component_tier, rarity_multiplier: rarity_multipliers[getItemRarity(quality_range[0])]});
-        const xp_val_2 = get_recipe_xp_value({category, subcategory, recipe_id, material_count: material.count, result_tier: item_templates[material.result_id].component_tier, rarity_multiplier: rarity_multipliers[getItemRarity(quality_range[1])]});
+        const xp_val_1 = get_recipe_xp_value({category, subcategory, recipe_id, material_count: material.count, result_tier: result_tier, rarity_multiplier: rarity_multipliers[getItemRarity(quality_range[0])]});
+        const xp_val_2 = get_recipe_xp_value({category, subcategory, recipe_id, material_count: material.count, result_tier: result_tier, rarity_multiplier: rarity_multipliers[getItemRarity(quality_range[1])]});
 
         tooltip += `<br>XP value: ${xp_val_1} - ${xp_val_2}<br>`;
         tooltip += `<br>Result:<br><div class="recipe_result">${create_item_tooltip_content({item: item_templates[material.result_id], options: {quality: quality_range}})}</div>`;
@@ -3490,11 +3484,17 @@ function update_gathering_tooltip(activity) {
 }
 
 function update_displayed_health() { //call it when using healing items, resting or getting hit
-    current_health_value_div.innerText = Math.ceil(character.stats.full.health) + "/" + Math.ceil(character.stats.full.max_health) + " hp";
+    let total_regen = character.stats.get_health_regeneration_total() - character.stats.get_health_loss_total();
+    current_health_value_div.innerText = Math.ceil(character.stats.full.health) + "/" + Math.ceil(character.stats.full.max_health)
+        + (total_regen != 0 ? " (+" + expo(total_regen, 1) + "/s) " : "")
+        + " hp";
     current_health_bar.style.width = (character.stats.full.health*100/character.stats.full.max_health).toString() +"%";
 }
 function update_displayed_stamina() { //call it when eating, resting or fighting
-    current_stamina_value_div.innerText = Math.round(character.stats.full.stamina) + "/" + Math.round(character.stats.full.max_stamina) + " stamina";
+    let total_regen = character.stats.get_stamina_regeneration_total();
+    current_stamina_value_div.innerText = Math.round(character.stats.full.stamina) + "/" + Math.round(character.stats.full.max_stamina)
+        + (total_regen != 0 ? " (+" + expo(total_regen, 1) + "/s) " : "")
+        + "stamina";
     current_stamina_bar.style.width = (character.stats.full.stamina*100/character.stats.full.max_stamina).toString() +"%";
 }
 
@@ -3944,7 +3944,7 @@ function update_displayed_item_log() {
     let html_content = "<table id='item_log_table'><tr><th width='100%'>Item</th><th>Best</th><th>Total</th></tr>";
 
     Object.values(item_log.items).forEach(item => {
-        if(item_templates[item.id].components) {
+        if(!item_templates[item.id] || item_templates[item.id].components) {
             return;
             /*
             skip stuff with components 
@@ -3957,7 +3957,7 @@ function update_displayed_item_log() {
 
         html_content += `<tr><td>${name}</td ><td>`;
 
-        if(item.quality_highest > 0 && !item_templates[item.id].ignore_quality) {
+        if(item.quality_highest > 0 && item_templates[item.id].use_quality) {
             const color = rarity_colors[getItemRarity(item.quality_highest)];
             const outline_class = select_outline_class(color);
             //html_content += `${item.quality_lowest}-${item.quality_highest}%`;

--- a/src/items.js
+++ b/src/items.js
@@ -158,6 +158,7 @@ class Item {
                 market_saturation_group,
                 saturates_market,
                 material_type = null,
+                use_quality = false,
                 quality = null,
                 rarity,
                 id = null, //passed only on loading, no need to provide it when creating new item objects as it will be filled automatically in that case
@@ -174,7 +175,8 @@ class Item {
         this.saturates_market = saturates_market ?? true;
 
         this.material_type = material_type;
-
+        
+        this.use_quality = use_quality;
         this.quality = quality;
         this.components = components; //meaningless unless it's an equippable that's /meant/ to have components
 
@@ -290,6 +292,37 @@ class Material extends OtherItem {
         super(item_data);
         this.item_type = "MATERIAL";
         this.tags["material"] = true;
+        this.quality = Math.round(item_data.quality) || null;
+
+        if (item_data.base_size) {
+            this.base_size = item_data.base_size;
+        }
+    }
+
+    getRarity(quality){
+        if(!quality) {
+            if(!this.rarity) {
+                this.rarity = getItemRarity(this.quality);
+            }
+            return this.rarity;
+        } else {
+            return getItemRarity(quality);
+        }
+    }
+
+    getSize(quality) {
+        if(!quality) {
+            if(!this.size_value) {
+                this.size_value = this.calculateSize(this.quality);
+            }
+            return this.size_value;
+        } else {
+            return this.calculateSize(quality);
+        }
+    }
+
+    calculateSize(quality) {
+        return Math.ceil((this.base_size * 10 || 0) / 10  * (quality/100 || this.quality/100) * rarity_multipliers[this.getRarity(quality || this.quality)]);
     }
 }
 
@@ -301,6 +334,7 @@ class ItemComponent extends Item {
         this.component_stats = item_data.component_stats || {};
         this.component_bonus_skill_levels = item_data.component_bonus_skill_levels || {};
         this.tags["component"] = true;
+        this.use_quality = item_data.use_quality ?? true;
         this.quality = Math.round(item_data.quality) || 100;
     }
 
@@ -447,6 +481,7 @@ class Equippable extends Item {
         this.item_type = "EQUIPPABLE";
         this.base_bonus_skill_levels = item_data.base_bonus_skill_levels;
 
+        this.use_quality = item_data.use_quality ?? true;
         this.quality = Math.round(Number(item_data.quality)) || 100;
 
         this.tags["equippable"] = true;
@@ -463,7 +498,7 @@ class Equippable extends Item {
             return tier;
         } else if(this.component_tier) {
             return this.component_tier;
-        } else {
+        } else { 
             return 1;
         }
     }
@@ -665,7 +700,7 @@ class Artifact extends Equippable {
         super(item_data);
         this.equip_slot = "artifact";
         this.stats = item_data.stats;
-        this.ignore_quality = true;
+        this.use_quality = false;
 
         this.tags["artifact"] = true;
         if(!this.id) {
@@ -682,7 +717,7 @@ class Tool extends Equippable {
     constructor(item_data) {
         super(item_data);
         this.equip_slot = item_data.equip_slot; //tool type is same as equip slot (axe/pickaxe/herb sickle)
-        this.ignore_quality = true;
+        this.use_quality = false;
         this.tags["tool"] = true;
         this.tags[this.equip_slot] = true;
         if(!this.id) {
@@ -994,8 +1029,9 @@ class Amulet extends Equippable {
         super(item_data);
         this.equip_slot = "amulet";
         this.stats = item_data.stats;
+        this.item_tier = item_data.item_tier;
 
-        this.ignore_quality = true;
+        this.use_quality = item_data.use_quality ?? false;
 
         this.tags["amulet"] = true;
         if(!this.id) {
@@ -1012,8 +1048,8 @@ class Ring extends Equippable {
         super(item_data);
         this.equip_slot = "ring";
         this.stats = item_data.stats;
-
-        this.ignore_quality = true;
+        
+        this.use_quality = item_data.use_quality ?? false;
 
         this.tags["ring"] = true;
         if(!this.id) {
@@ -1141,6 +1177,7 @@ function getItem(item_data) {
         case "MATERIAL":
             return new Material(item_data);
         default:
+            console.log(item_data);
             throw new Error(`Wrong item type: ${item_data.item_type}`);
     }
 }
@@ -1238,8 +1275,10 @@ book_stats["Medicine for dummies"] = new BookData({
         recipes: [
             {category: "alchemy", subcategory: "items", recipe_id: "Weak healing powder"},
             {category: "alchemy", subcategory: "items", recipe_id: "Healing balm"},
+            {category: "alchemy", subcategory: "items", recipe_id: "Thick healing balm"},
             {category: "alchemy", subcategory: "items", recipe_id: "Oneberry juice"},
             {category: "alchemy", subcategory: "items", recipe_id: "Healing powder"},
+            {category: "alchemy", subcategory: "items", recipe_id: "Potent healing powder"},
             {category: "alchemy", subcategory: "items", recipe_id: "Healing potion"},
             {category: "alchemy", subcategory: "items", recipe_id: "Potion of sapping"}, //not a medicine, but has to be somewhere
         ],
@@ -1664,7 +1703,6 @@ book_stats["Wood for Witches"] = new BookData({
         value: 50,
         material_type: "raw wood",
     });
-    //right now mostly meant as an additional source of charcoal, hopefully more uses after magic and housing
     item_templates["Piece of willow wood"] = new Material({
         description: "Not suitable for weapons, but may have other uses",
         value: 5,
@@ -1751,12 +1789,16 @@ book_stats["Wood for Witches"] = new BookData({
     item_templates["Ratfish"] = new Material({
         name: "Ratfish",
         description: "A small sweetwater fish, named after its unremarkable coloration and propensity to travel in large groups",
+        use_quality: true,
+        base_size: 5,
         value: 5,
         material_type: "small fish",
     });
     item_templates["Minnow"] = new Material({
         name: "Minnow",
         description: "One of the variety of small fish that inhabit rivers and streams",
+        use_quality: true,
+        base_size: 10,
         value: 10,
         material_type: "small fish",
     });
@@ -1764,25 +1806,33 @@ book_stats["Wood for Witches"] = new BookData({
     item_templates["Mackerel shark"] = new Material({
         name: "Mackerel shark",
         description: "A shark small enough to fit in a stream. Makes up for its size with its feistiness and big mouth",
-        value: 50,
+        use_quality: true,
+        base_size: 35,
+        value: 85,
         material_type: "medium fish",
     });
     item_templates["Trout"] = new Material({
         name: "Trout",
         description: "A fish large enough for a full meal and common in most rivers, making it a convenient source of food. So far, this has not effected their population",
-        value: 50,
+        use_quality: true,
+        base_size: 60,
+        value: 110,
         material_type: "medium fish",
     });
 
     item_templates["Carp"] = new Material({
         name: "Carp",
         description: "It hasn't grown into any of its more powerful forms yet, so its meat is still fatty and plump",
-        value: 50,
+        use_quality: true,
+        base_size: 50,
+        value: 150,
         material_type: "medium fish",
     });
     item_templates["Catfish"] = new Material({
         name: "Catfish",
         description: "A large fish with whiskers. Usually found near the bottom of lakes, where it feeds on ratfish and pretty much everything else it can hunt",
+        use_quality: true,
+        base_size: 100,
         value: 200,
         material_type: "large fish",
     });
@@ -4186,11 +4236,13 @@ function add_gear() {
     (function () {
         item_templates["Wool scarf"] = new Amulet({
             value: 100,
+            item_tier: 2,
+            use_quality: true,
             stats: {
                 cold_tolerance: {
                     flat: 5,
                 }
-            },
+            }
         });
         item_templates["Warrior's necklace"] = new Amulet({
             value: 1000,
@@ -4319,6 +4371,24 @@ function add_gear() {
             equip_slot: "fishing_pole",
             base_bonus_skill_levels: {
                 "Fishing": 5,
+            }
+        });
+        item_templates["Hickory wood fishing pole"] = new Tool({
+            name: "Hickory wood fishing pole",
+            description: "A good fishing pole made out of quality materials",
+            value: 900,
+            equip_slot: "fishing_pole",
+            base_bonus_skill_levels: {
+                "Fishing": 7,
+            }
+        });
+        item_templates["Alchemical wood fishing pole"] = new Tool({
+            name: "Alchemical wood fishing pole",
+            description: "An excellent fishing pole made out of state-of-the-art materials",
+            value: 1400,
+            equip_slot: "fishing_pole",
+            base_bonus_skill_levels: {
+                "Fishing": 10,
             }
         });
     })();
@@ -4467,6 +4537,10 @@ function add_gear() {
     item_templates["Sinew string"] = new Material({
         description: "Tough, durable fiber, processed from animal tissue",
         value: 20,
+    });
+    item_templates["Flax string"] = new Material({
+        description: "Strong and durable linen fiber",
+        value: 35,
     });
     item_templates["Wool cloth"] = new Material({
         description: "Thick and warm, might possibly absorb some punches",
@@ -4661,12 +4735,18 @@ function add_gear() {
         effects: [{effect: "Weak healing powder", duration: 240}],
         tags: {"medicine": true},
     });
-
     item_templates["Healing powder"] = new UsableItem({
         name: "Healing powder",
         description: "Not exactly powerful in its effects, but still makes the body heal noticeably faster and for a long time",
         value: 100,
         effects: [{effect: "Healing powder", duration: 300}],
+        tags: {"medicine": true},
+    });
+    item_templates["Potent healing powder"] = new UsableItem({
+        name: "Potent healing powder",
+        description: "Makes the body heal significantly faster and for a long time",
+        value: 220,
+        effects: [{effect: "Potent healing powder", duration: 300}],
         tags: {"medicine": true},
     });
 
@@ -4698,6 +4778,13 @@ function add_gear() {
         description: "Simply apply it to your wound and watch it heal",
         value: 120,
         effects: [{effect: "Weak healing balm", duration: 90}],
+        tags: {"medicine": true},
+    });
+    item_templates["Thick healing balm"] = new UsableItem({
+        name: "Thick healing balm",
+        description: "Simply apply it to your wound and watch it quickly heal",
+        value: 300,
+        effects: [{effect: "Healing balm", duration: 90}],
         tags: {"medicine": true},
     });
 
@@ -4811,19 +4898,18 @@ function add_gear() {
         tags: {"food": true},
     });
 	
-    //TODO made them tier 2 and 3 for now, but are hard enough to get that they could be bumped to tier 4?
     item_templates["Fried frog meat"] = new UsableItem({
         name: "Fried frog meat",
         description: "Tastes a bit like bird, and a bit like fish",
-        value: 50,
-        effects: [{effect: "Simple meat meal", duration: 120}],
+        value: 100,
+        effects: [{effect: "Decent meat meal", duration: 120}],
         tags: {"food": true},
     });
     item_templates["Kingsized frog legs"] = new UsableItem({
         name: "Kingsized frog legs",
         description: "The legs are agreed to be the best part, and when cooked with proper seasoning, considered a delicacy by some",
-        value: 100,
-        effects: [{effect: "Decent meat meal", duration: 120}],
+        value: 200,
+        effects: [{effect: "Tasty meat meal", duration: 120}],
         tags: {"food": true},
     });
 
@@ -4873,7 +4959,7 @@ export {
     item_log,
     Item, OtherItem, UsableItem,
     Armor, Shield, Weapon, Cape, Artifact, Book,
-    Material, WeaponComponent, ArmorComponent, ShieldComponent,
+    Material, WeaponComponent, ArmorComponent, ShieldComponent, Amulet,
     getItem, getItemFromKey,
     round_item_price, getArmorSlot, getEquipmentValue,
     book_stats, BookData,

--- a/src/locations.js
+++ b/src/locations.js
@@ -8,7 +8,7 @@ import { get_total_skill_level, get_skill_modifier, is_rat } from "./character.j
 import { GameAction } from "./actions.js";
 import { fill_market_regions, market_regions } from "./market_saturation.js";
 import { global_flags } from "./main.js";
-import { slerp } from "./misc.js";
+import { clamp, slerp } from "./misc.js";
 const locations = {}; //contains all the created locations
 const location_types = {};
 
@@ -376,6 +376,7 @@ class LocationActivity{
                 time_period: [min,max], 
                 skill_required: [min_efficiency, max_efficiency]
                 scales_with_skill: deprecated, all checks are done through 'skill_required'
+                roll_quality: boolean, whether dropped items have quality
             }
         */
         //every 2-value array is oriented [starting_value, value_with_required_skill_level], except for subarrays of ammount (which are for randomizing gained item count) and for skill_required
@@ -417,7 +418,19 @@ class LocationActivity{
             gained_resources.push({name: this.gained_resources.resources[i].name, count: [min,max], chance: chance});
         }
 
-        return {gathering_time_needed, gained_resources};
+        if (!this.gained_resources.roll_quality) {
+            return { gathering_time_needed, gained_resources };
+        }
+        else {
+            const skill = skills[activities[this.activity_name].base_skills_names[0]];
+            const quality_cap = Math.min(Math.round(100+2*get_total_skill_level(skill.skill_id)),200);
+            const quality = (3 * get_total_skill_level(skill.skill_id) - skill.max_level) + 130/* + (15 * tier)*/;
+            const quality_range = [
+                clamp(Math.round(quality - 15), 10, quality_cap),
+                clamp(Math.round(quality + 10), 10, quality_cap),
+            ];
+            return { gathering_time_needed, gained_resources, quality_range}
+        }
     }
 }
 
@@ -699,7 +712,7 @@ function get_location_type_penalty(type, stage, stat, category) {
         name: "aquatic",
         stages: {
             1: {
-                description: "Wading in water up to your knees restrict your movement",
+                description: "Wading in water up to your knees restricts your movement",
                 related_skill: "Swimming",
                 scaling_lvl: 30,
                 effects: {
@@ -2261,7 +2274,8 @@ There's another gate on the wall in front of you, but you have a strange feeling
                     {name: "Minnow", chance: [0.1, 0.5]},
                     {name: "Trout", chance: [0.01, 0.20]},
                     {name: "Mackerel shark", chance: [0.001, 0.05]}
-                ], 
+                ],
+                roll_quality: true,
                 time_period: [120, 30],
                 skill_required: [0, 10],
             },
@@ -2633,7 +2647,8 @@ There's another gate on the wall in front of you, but you have a strange feeling
                     {name: "Cooking herbs", ammount: [[1,1], [1,2]], chance: [0.3, 0.6]}
                 ], 
                 time_period: [90, 45],
-                skill_required: [21, 28]
+                skill_required: [21, 28],
+                roll_quality: true,
             }
         }),
     };

--- a/src/main.js
+++ b/src/main.js
@@ -4065,8 +4065,8 @@ function load(save_data) {
                     }
                 } else if(quality) { //no comps but quality (clothing / artifact /)
                     const item_id = get_component_name(id);
-                    const new_item_key = item_templates[item_id].getInventoryKey();
-                    item_list.push({item_key: new_item_key, count: save_data.character.inventory[key].count, quality: quality});
+                    //const new_item_key = item_templates[item_id].getInventoryKey();
+                    item_list.push({item_id: item_id, count: save_data.character.inventory[key].count, quality: quality});
                 } else {
                     console.error(`Intentory key "${key}" from save on version "${save_data["game version"]} is incorrect!`);
                 }
@@ -5484,7 +5484,7 @@ function update() {
                 //ticks are varied for gathering activities, 1 second for most other activities
                 current_activity.gathering_time += 1;
                 if(current_activity.gathering_time >= current_activity.gathering_time_needed) { 
-                    const {gathering_time_needed, gained_resources} = current_activity.getActivityEfficiency();
+                    const {gathering_time_needed, gained_resources, quality_range} = current_activity.getActivityEfficiency();
                     const items = [];
 
                     //add xp
@@ -5507,8 +5507,14 @@ function update() {
                         for(let i = 0; i < gained_resources.length; i++) {
                             if(Math.random() > (1-gained_resources[i].chance)) {
                                 const count = random_range(gained_resources[i].count[0], gained_resources[i].count[1]);
-                            
-                                items.push({item_key: item_templates[gained_resources[i].name].getInventoryKey(), count: count});
+                                let quality = null;
+
+                                //quality
+                                if (quality_range) {
+                                    quality = Math.round(random_range(quality_range[0], quality_range[1]) / 4) * 4;
+                                }
+
+                                items.push({item_id: gained_resources[i].name, quality: quality, count: count});
 
                                 gathered_materials[gained_resources[i].name] = (gathered_materials[gained_resources[i].name] || 0) + count;
                             }


### PR DESCRIPTION
- Regen/drain values visible on health stamina bars
- Quality visible on inventory items
- Materials (in this case fish) can now roll quality, if the appropriate flags are set on both the items and their gathering node
- Several new crafting recipes
- Some tweaks to item tooltip code - more properties are displayed based on what's actually on the item, rather than its type.
- fixed a bug where items would lose their quality on load