### PR TITLE
Fourteen measured fixes found while working from a fork

### DIFF
--- a/build.js
+++ b/build.js
@@ -24,13 +24,20 @@ esbuild
         const htmlPath = 'index.html';
         let htmlContent = fs.readFileSync(htmlPath, 'utf8');
 
+        /*
+            Exit non-zero rather than return. The bundle is already written at this point,
+            so returning leaves a new dist/bundle.js on disk with index.html still asking
+            for the old ?version= - and dist/ is committed, so that is a bundle no
+            browser will fetch, reported as a successful build. Anything chaining off this
+            (`node build.js && ...`) could not tell.
+        */
         if(htmlContent.search(bundle_regex) == -1) {
-            console.log(styleText("red", 'Failed to update the bundle version in .html!'));
-            return;
+            console.error(styleText("red", 'Failed to update the bundle version in .html!'));
+            process.exit(1);
         }
         if(htmlContent.search(style_regex) == -1) {
-            console.log(styleText("red", 'Failed to update the style version in .html!'));
-            return;
+            console.error(styleText("red", 'Failed to update the style version in .html!'));
+            process.exit(1);
         }
 
         htmlContent = htmlContent.replace(
@@ -44,7 +51,9 @@ esbuild
             fs.writeFileSync(htmlPath, htmlContent);
             console.log("Bundle and style versions in .html have been updated!");
         } catch (err) {
+            //Also non-zero: the bundle is on disk and index.html was not updated.
             console.error(err);
+            process.exit(1);
         }
         
     }).catch(() => process.exit(1));

--- a/src/conditions.js
+++ b/src/conditions.js
@@ -168,24 +168,42 @@ const process_conditions = (conditions, context) => {
 
     if(conditions[0].location_clears) {
         Object.keys(conditions[0].location_clears).forEach(location_key => {
-            const location = context.locations[location_key]; //error here
-            if("at_least" in conditions[0].location_clears[location_key]) {
-                if(Math.floor(location.enemy_groups_killed/location.enemy_count) < conditions[0].location_clears[location_key].at_least) {
-                    met = 0;
-                }
+            const location = context.locations[location_key];
+            if(!location) {
+                console.error(`A condition asks for clears of "${location_key}", which is not a location.`);
+                met = 0;
+                return;
             }
 
-            if("at_most" in conditions[0].location_clears[location_key]) {
-                if(Math.floor(location.enemy_groups_killed/location.enemy_count) > conditions[0].location_clears[location_key].at_most) {
-                    met = 0;
-                }
+            /*
+                A location with no enemy_count - every non-combat one - would divide to
+                NaN, and every comparison against NaN is false, so an at_least gate would
+                silently OPEN instead of closing. Zero clears is the honest answer.
+            */
+            const clears = location.enemy_count
+                ? Math.floor(location.enemy_groups_killed / location.enemy_count)
+                : 0;
+            const wanted = conditions[0].location_clears[location_key];
+
+            if("at_least" in wanted && clears < wanted.at_least) {
+                met = 0;
+            }
+            if("at_most" in wanted && clears > wanted.at_most) {
+                met = 0;
             }
         });
     }
 
     if(conditions[0].quests_completed) {
         for(let i = 0; i < conditions[0].quests_completed.length; i++) {
-            if(!context.quests[conditions[0].quests_completed[i]].is_finished) {
+            const quest = context.quests[conditions[0].quests_completed[i]];
+            if(!quest) {
+                console.error(`A condition requires quest "${conditions[0].quests_completed[i]}" to be finished, but no such quest exists.`);
+                met = 0;
+            } else if(!quest.isFinished()) {
+                //isFinished(), not .is_finished: the field moved into the availability
+                //component, so reading it off the instance is always undefined and this
+                //gate always reported "not finished".
                 met = 0;
             }
         }
@@ -193,7 +211,13 @@ const process_conditions = (conditions, context) => {
 
     if(conditions[0].quests_not_completed) {
         for(let i = 0; i < conditions[0].quests_not_completed.length; i++) {
-            if(quests[conditions[0].quests_not_completed[i]].is_finished) {
+            //context.quests, not a bare `quests`: this file imports nothing on purpose,
+            //so the bare reference threw ReferenceError the first time content used it.
+            const quest = context.quests[conditions[0].quests_not_completed[i]];
+            if(!quest) {
+                console.error(`A condition requires quest "${conditions[0].quests_not_completed[i]}" to be unfinished, but no such quest exists.`);
+                met = 0;
+            } else if(quest.isFinished()) {
                 met = 0;
             }
         }

--- a/src/data/locations.js
+++ b/src/data/locations.js
@@ -3220,7 +3220,7 @@ There's another gate on the wall in front of you, but you have a strange feeling
                 conditional_loss: ["You need to get more used to water and have lung capacity to go that deep"],
                 random_loss: [`You may have felt like you can already brave anything this forest can throw at you. But the part stretching before you is more imposing than anything you've seen so far.\n\n
 The river coming from the lake vanishes in darkness as the foliage is too dense to let in light. The trees there are growing larger, denser... More ancient.\n\n
-You try to make make out the details of what looks like a bird flying in the distance. It has four legs... [tbc]`],
+You try to make out the details of what looks like a bird flying in the distance. It has four legs... [tbc]`],
             },
             is_unlocked: true,
             success_chances: [0,0],

--- a/src/display.js
+++ b/src/display.js
@@ -4959,13 +4959,14 @@ function create_new_bestiary_entry(enemy_name) {
         if(rank_a != rank_b) {
             return rank_a - rank_b;
         } else {
-            const name_a = a.querySelector(".bestiary_entry_name").innerText;
-            const name_b = b.querySelector(".bestiary_entry_name").innerText;
-            if(name_a > name_b) {
-                return 1;
-            } else {
-                return -1;
-            }
+            /*
+                localeCompare rather than `>`: comparing strings with `>` orders them by
+                UTF-16 code unit, which puts every accented or non-ASCII letter after Z.
+                It also never returns 0, so two entries with the same name flip order on
+                every re-sort.
+            */
+            return a.querySelector(".bestiary_entry_name").innerText
+                .localeCompare(b.querySelector(".bestiary_entry_name").innerText);
         }
     }).forEach(node=>bestiary_list.appendChild(node));
 }
@@ -5175,8 +5176,14 @@ function create_new_booklist_entry(book_name) {
 
     booklist_list.appendChild(booklist_entry_divs[book_name]);
 
-    //sorts booklist_list div by book title
-    [...booklist_list.children].sort((a,b)=>a.getAttribute("data-book") - b.getAttribute("data-book"))
+    /*
+        Sorts by title. Subtracting one title from another - which is what this did - is
+        NaN for every pair of strings, and a comparator that always returns NaN sorts
+        nothing: the anthology was in whatever order the books happened to be read in.
+    */
+    [...booklist_list.children].sort((a, b) =>
+                                    a.getAttribute("data-book")
+                                        .localeCompare(b.getAttribute("data-book")))
                                 .forEach(node=>booklist_list.appendChild(node));
 }
 

--- a/src/display.js
+++ b/src/display.js
@@ -604,6 +604,28 @@ function create_item_tooltip_content({item, options={}, is_trade = false}) {
 /** 
  * @param {Object} item_effect from item effects[]
  */
+/**
+ * What to call an xp multiplier's target: a skill's name, a category, or an aggregate.
+ *
+ * The three places that needed this had three different answers - one handled
+ * category_ targets, two did not, and none of them checked that a named skill exists
+ * before asking it for its name. A misspelled target in content should read oddly, not
+ * throw while drawing a tooltip.
+ */
+function xp_target_name(target) {
+    if(target === "all" || target === "hero" || target === "all_skill") {
+        return target.replace("_", " ");
+    }
+    if(target.includes("category_")) {
+        return target.replace("category_", "") + " skills";
+    }
+    if(!skills[target]) {
+        console.warn(`An xp multiplier names "${target}", which is not a skill, a category`
+            + ` or an aggregate. Possibly a misspelling.`);
+        return target;
+    }
+    return skills[target].getName();
+}
 function create_effect_tooltip({effect_name, duration, add_bonus=false}) {
     const effect = effect_templates[effect_name];
     const tooltip = document.createElement("div");
@@ -663,13 +685,9 @@ function create_effect_tooltip({effect_name, duration, add_bonus=false}) {
     
     const xp_multipliers = Object.keys(effects.xp_multipliers);
     if(xp_multipliers.length > 0) {
-        let name;
-        if(xp_multipliers[0] !== "all" && xp_multipliers[0] !== "hero" && xp_multipliers[0] !== "all_skill") {
-            name = skills[xp_multipliers[0]].getName();
-        } else {
-            name = xp_multipliers[0].replace("_"," ");
-        }
-        name = capitalize_first_letter(name);
+        //Same three cases models/skill.js handles, including category_ - which this copy
+        //did not, so a category target would have asked the skill registry for it.
+        const name = capitalize_first_letter(xp_target_name(xp_multipliers[0]));
         if(tooltip_html_content) {
             tooltip_html_content += `<br>${name} xp gain: x${effects.xp_multipliers[xp_multipliers[0]]}`;
         } else {
@@ -911,12 +929,7 @@ function format_book_bonuses(bonuses) {
     }
     if(bonuses.xp_multipliers) {
         const xp_multipliers = Object.keys(bonuses.xp_multipliers);
-        let name;
-        if(xp_multipliers[0] !== "all" && xp_multipliers[0] !== "hero" && xp_multipliers[0] !== "all_skill") {
-            name = skills[xp_multipliers[0]].getName();
-        } else {
-            name = xp_multipliers[0].replace("_"," ");
-        }
+        const name = xp_target_name(xp_multipliers[0]);
 
         if(formatted) {
             formatted += `, x${bonuses.xp_multipliers[xp_multipliers[0]]} ${name} xp gain`;

--- a/src/display.js
+++ b/src/display.js
@@ -4762,7 +4762,7 @@ function update_skill_category_order() {
 /**
  * @description updates the list of stances, 
  */
-function update_displayed_stance_list(stances, current_stance, fav_stances) {
+function update_displayed_stance_list(stances, current_stance) {
 
     clear_HTML_content(stance_list);
 
@@ -4827,7 +4827,7 @@ function update_displayed_stance_list(stances, current_stance, fav_stances) {
     }).forEach(node=>stance_list.appendChild(node));
 
     update_displayed_stance(current_stance);
-    update_displayed_faved_stances(fav_stances);
+    update_displayed_faved_stances(stances);
 }
 
 function create_stance_tooltip(stance) {
@@ -4894,6 +4894,9 @@ function update_displayed_stance(stance) {
     }
 }
 
+//The argument is the stance REGISTRY, not the faved_stances map: which ids are starred
+//is imported from main.js, and what is needed here is the object those ids resolve
+//through.
 function update_displayed_faved_stances(stances) {
     
     const list = document.getElementById("character_stance_selection");

--- a/src/items.js
+++ b/src/items.js
@@ -4767,7 +4767,9 @@ function add_gear() {
     });
 
     item_templates["Cooked potato"] = new UsableItem({
-        name: "Potato", description: "A common tuber with versatile culinary usage, though this one was simply cooked",
+        //"Cooked potato", not "Potato": the name is what the player reads, and this one
+        //made a cooked potato indistinguishable from the raw one in the inventory.
+        name: "Cooked potato", description: "A common tuber with versatile culinary usage, though this one was simply cooked",
         value: 40,
         effects: [{effect: "Basic meal", duration: 150}],
         tags: {"food": true},

--- a/src/items.js
+++ b/src/items.js
@@ -358,6 +358,16 @@ class ItemComponent extends Item {
         this.tags["component"] = true;
         this.use_quality = item_data.use_quality ?? true;
         this.quality = Math.round(item_data.quality) || 100;
+
+        /*
+            The material a shown name is assembled from. crafting_component_filling.js has
+            always passed this and no class stored it, so `material_id` was undefined on
+            every component instance - which means the assembleName branch of
+            Armor.getDisplayName and Shield.getDisplayName can never run, and every
+            generated helmet, armour, glove, shoe, trouser, shield and weapon falls through
+            to its raw English name.
+        */
+        this.material_id = item_data.material_id;
     }
 
     getRarity(quality){
@@ -450,6 +460,8 @@ class ArmorComponent extends ItemComponent {
         }
         this.component_type = item_data.component_type;
         this.defense_value = item_data.defense_value;
+        //The piece word a full armor name ends in; passed by the generator, never stored.
+        this.armor_piece = item_data.armor_piece;
 
         this.stats = item_data.stats || {};
 

--- a/src/main.js
+++ b/src/main.js
@@ -3650,6 +3650,37 @@ function create_save() {
  * called from index.html
  * @returns save string encoded to base64
  */
+/**
+ * Base64 for text that is not Latin-1.
+ *
+ * btoa throws InvalidCharacterError on any character above U+00FF, and the savefile
+ * carries the hero's name - which the player types. A hero called Ayşe, José or Müller
+ * makes every export throw, and because the throw happens inside the Export button's
+ * onclick it is silent: the button simply does nothing.
+ *
+ * Older exports still load. One could only ever have been produced from pure Latin-1,
+ * and decoding ASCII as UTF-8 gives ASCII back.
+ *
+ * The loops are deliberate: String.fromCharCode(...bytes) spreads a whole savefile
+ * across the argument list and overflows the stack on a long one.
+ */
+function to_base64(text) {
+    const bytes = new TextEncoder().encode(text);
+    let latin1 = "";
+    for(let i = 0; i < bytes.length; i++) {
+        latin1 += String.fromCharCode(bytes[i]);
+    }
+    return btoa(latin1);
+}
+
+function from_base64(encoded) {
+    const latin1 = atob(encoded);
+    const bytes = new Uint8Array(latin1.length);
+    for(let i = 0; i < latin1.length; i++) {
+        bytes[i] = latin1.charCodeAt(i);
+    }
+    return new TextDecoder().decode(bytes);
+}
 function save_to_file() {
     if(Date.now() - last_rewarded_export > config.time_between_export_rewards) {
         last_rewarded_export = Date.now();
@@ -3658,7 +3689,7 @@ function save_to_file() {
 
     //will create save twice...
     save_progress();
-    return btoa(create_save());
+    return to_base64(create_save());
 }
 
 /**
@@ -5378,9 +5409,9 @@ function load(save_data) {
 function load_from_file(save_string) {
     try{
         if(is_on_dev()) {
-            localStorage.setItem(dev_save_key, atob(save_string));
+            localStorage.setItem(dev_save_key, from_base64(save_string));
         } else {
-            localStorage.setItem(save_key, atob(save_string));
+            localStorage.setItem(save_key, from_base64(save_string));
         }        
         window.location.reload(false);
     } catch (error) {

--- a/src/main.js
+++ b/src/main.js
@@ -846,7 +846,12 @@ function finish_game_action({action_key, conditions_status, dialogue_key}){
         } else {
             //random loss
 
-            result_message = action.failure_texts.random_loss[Math.floor(action.failure_texts.random_loss.length * Math.random())];
+            //An empty list indexed at Math.floor(0 * random) is undefined, which reaches
+            //the player as a blank line or a missing-text marker depending on the caller.
+            const lines = action.failure_texts.random_loss;
+            result_message = lines?.length
+                ? lines[Math.floor(lines.length * Math.random())]
+                : result_message;
         }
 
         const success_conditions = action.getAvailabilityComponent().success_conditions;
@@ -855,7 +860,7 @@ function finish_game_action({action_key, conditions_status, dialogue_key}){
         Object.keys(success_conditions[0]?.items_by_id || {}).forEach(item_id => {
             //no need to check if they are in inventory, as without them action would have been conditionally failed before reaching here
             if(success_conditions[0].items_by_id[item_id].remove) {
-                character.removeFromInventory([{item_key: item_templates[item_id].getInventoryKey(), item_count: action.success_conditions[0].items_by_id[item_id].count}]);
+                character.removeFromInventory([{item_key: item_templates[item_id].getInventoryKey(), item_count: success_conditions[0].items_by_id[item_id].count}]);
             }
         });
         Object.keys(start_conditions.items_by_id || {}).forEach(item_id => {

--- a/src/main.js
+++ b/src/main.js
@@ -1700,6 +1700,8 @@ function do_enemy_combat_action(enemy_id) {
 
     damages_dealt = damages_dealt.sort((a,b)=>b-a);
     
+    let blocked_by_shield = false;
+
     if(character.getEquipment()["off-hand"]?.offhand_type === "shield") { //HAS SHIELD
         if(full_stats.block_chance > Math.random()) {//BLOCKED THE ATTACK
 
@@ -1716,11 +1718,26 @@ function do_enemy_combat_action(enemy_id) {
             } else {
                 damages_dealt = damages_dealt.map(val => Math.max(0,val-blocked));
                 partially_blocked = true;
+                blocked_by_shield = true;
             }
          } else {
             add_xp_to_skill({skill: skills["Shield blocking"], xp_to_add: attacker.xp_value/(2*enemy_count_xp_mod)});
          }
-    } else { // HAS NO SHIELD
+    }
+
+    /*
+        An attack the shield did not stop still gets dodged, if the character is quick
+        enough. This used to be the else-branch of the shield check, which meant that
+        carrying a shield removed the dodge outright - and with base_block_chance at 0.75,
+        a starter shield turned three quarters of the attacks into "reduced by the shield's
+        strength" and handed the remaining quarter a free full hit. A shield whose strength
+        is smaller than the damage it faces was therefore strictly worse than carrying
+        nothing at all, which is not what a starter shield should be.
+
+        An attack that WAS blocked skips this: it connected with the shield, so there is
+        nothing left to dodge.
+    */
+    if(!blocked_by_shield) {
         const hit_chance = get_hit_chance(attacker.stats.dexterity * Math.sqrt(attacker.stats.intuition ?? 1), full_stats.evasion_points*evasion_chance_modifier);
 
         if(hit_chance < Math.random()) { //EVADED ATTACK

--- a/src/main.js
+++ b/src/main.js
@@ -2229,7 +2229,46 @@ function get_location_rewards(location) {
  * @param {String} rewards_data.source_name //in case it's needed for logging a message
  * @param {Boolean} rewards_data.only_unlocks //processes only unlock-type rewards (skips money, item, etc; doesn't skip rep)
  */
+/*
+    The reward keys process_rewards reads, and the lock keys it reads inside `locks`.
+
+    Here so that a key it does NOT read gets said out loud. data/locations.js has a
+    reward written as `action:` where the function reads `rewards.actions`, so that
+    reward has never done anything - and nothing said so, because the skill_xp next to it
+    worked. A typo in a content file should not be invisible.
+*/
+const reward_keys = [
+    "actions", "activities", "crafting", "dialogues", "flags", "global_activities",
+    "housing", "items", "locations", "locks", "messages", "money", "move_to", "npcs",
+    "quest_progress", "quests", "recipes", "reputation", "skill_xp", "skills", "stances",
+    "textlines", "traders", "xp",
+];
+const lock_keys = ["actions", "locations", "npcs", "quests", "textlines"];
+
+/**
+ * Reports any key in a reward object that nothing will read.
+ *
+ * Called with the source so the message says where to look, because a reward object on
+ * its own is not something you can search for.
+ */
+function warn_about_unread_reward_keys(rewards, source_type, source_name) {
+    const where = source_name ? ` (${source_type} "${source_name}")` : "";
+
+    for(const key of Object.keys(rewards)) {
+        if(!reward_keys.includes(key)) {
+            console.warn(`Reward key "${key}"${where} is not read by process_rewards`
+                + ` - that reward does nothing. Valid keys: ${reward_keys.join(", ")}.`);
+        }
+    }
+    for(const key of Object.keys(rewards.locks || {})) {
+        if(!lock_keys.includes(key)) {
+            console.warn(`Lock key "${key}"${where} is not read by process_rewards`
+                + ` - that lock does nothing. Valid keys: ${lock_keys.join(", ")}.`);
+        }
+    }
+}
 function process_rewards({rewards = {}, source_type, source_name, is_first_clear, inform_overall = true, inform_textline = true, only_unlocks = false, is_from_loading = false}) {
+    warn_about_unread_reward_keys(rewards, source_type, source_name);
     let was_any_location_availability_changed = false;
     let is_current_location_reload_needed = false;
     if(rewards.messages && !is_from_loading) {

--- a/src/main.js
+++ b/src/main.js
@@ -2520,17 +2520,28 @@ function process_rewards({rewards = {}, source_type, source_name, is_first_clear
 
     if(rewards.items && !only_unlocks) {
         for(let i = 0; i < rewards.items.length; i++) {
-            let item;
-            let count;
-            if(typeof rewards.items[i] === "string") {
-                item = item_templates[rewards.items[i]];
-                count = 1;
-            } else {
-                item = item_templates[rewards.items[i].item];
-                count = rewards.items[i].count || 1;
-                item.quality = rewards.items[i].quality;
+            const entry = rewards.items[i];
+            const is_bare_name = typeof entry === "string";
+            const item_id = is_bare_name ? entry : entry.item;
+            const template = item_templates[item_id];
+
+            if(!template) {
+                console.error(`No such item as "${item_id}" - reward skipped.`);
+                continue;
             }
-            
+
+            const count = is_bare_name ? 1 : (entry.count || 1);
+            const quality = is_bare_name ? undefined : entry.quality;
+
+            //getItem instead of stamping the quality onto the template: getInventoryKey()
+            //caches into this.inventory_key, and a template's key is cached long before any
+            //reward is granted, so `item.quality = ...` never reached the key - the five
+            //starter weapons in dialogues.js ask for quality 50 and arrived at 100, worth
+            //double. It also wrote to the shared template, where getBaseValue's
+            //`quality || this.quality || 100` fallback reads it. This is the same call
+            //components/inventory_component.js makes for the item_id form.
+            const item = quality ? getItem({...template, quality}) : template;
+
             log_message(`%HeroName% obtained "${item.getName()} x${count}"`);
             character.addToInventory([{item_key: item.getInventoryKey(), count}]);
         }

--- a/src/main.js
+++ b/src/main.js
@@ -1337,7 +1337,7 @@ function unlock_combat_stance(stance_id) {
         log_message(`You have learned a new stance: "${stances[stance_id].name}"`, "location_unlocked");
     }
     stances[stance_id].setUnlocked();
-    update_displayed_stance_list(stances, current_stance, faved_stances);
+    update_displayed_stance_list(stances, current_stance);
 }
 
 function change_stance({stance_id, is_temporary = false}) {
@@ -4017,7 +4017,7 @@ function load(save_data) {
             });
         }
 
-        update_displayed_stance_list(stances, current_stance, faved_stances);
+        update_displayed_stance_list(stances, current_stance);
 
         if(save_data.faved_stances) {
             Object.keys(save_data.faved_stances).forEach(stance_id=> {
@@ -6162,7 +6162,7 @@ if(!is_on_dev() && save_key in localStorage || is_on_dev() && (dev_save_key in l
     update_displayed_money();
     character.updateStatsAndDisplay();
 
-    update_displayed_stance_list(stances, current_stance, faved_stances);
+    update_displayed_stance_list(stances, current_stance);
     change_stance({stance_id: "normal"});
     create_displayed_crafting_recipes();
     change_location({location_id: "Village", skip_travel_time: true});

--- a/src/main.js
+++ b/src/main.js
@@ -1686,7 +1686,11 @@ function do_enemy_combat_action(enemy_id) {
                 add_xp_to_skill({skill, xp_to_add: attacker.xp_value/enemy_count_xp_mod});
                 const {modifier_to_evasion, modifier_to_defense} = skill.get_stat_modifiers();
                 evasion_chance_modifier *= modifier_to_evasion || 1;
-                defense_modifier += modifier_to_defense || 1;
+                //`|| 0`, not `|| 1`: this one is a SUM, and 1 is the identity for the
+                //multiplication on the line above, not for addition. Most skills return no
+                //modifier_to_defense at all, so every matched tag-skill was handing out a
+                //free point of defence that no skill declares.
+                defense_modifier += modifier_to_defense || 0;
             }
         }
     });

--- a/src/models/skill.js
+++ b/src/models/skill.js
@@ -251,9 +251,14 @@ class Skill {
                         Object.keys(gains.xp_multipliers).forEach(xp_multiplier => {
                             let name;
                             if(xp_multiplier !== "all" && xp_multiplier !== "hero" && xp_multiplier !== "all_skill" && !xp_multiplier.includes("category_")) {
-                                name = skills[xp_multiplier].getName();
+                                //The check has to come first: it was written to explain
+                                //this crash and was sitting underneath it, so it could
+                                //never print.
                                 if(!skills[xp_multiplier]) {
                                     console.warn(`Skill ${this.skill_id} tried to reward an xp multiplier for something that doesn't exist: ${xp_multiplier}. I could be a misspelled skill name`);
+                                    name = xp_multiplier;
+                                } else {
+                                    name = skills[xp_multiplier].getName();
                                 }
                             } else {
                                 

--- a/tests/bundle-loads.mjs
+++ b/tests/bundle-loads.mjs
@@ -1,0 +1,137 @@
+/**
+ * Evaluates dist/bundle.js the way a browser does, and fails if it throws.
+ *
+ * The imports in src/ are circular by design - many modules import back from main.js -
+ * and that cycle only resolves in a browser, where main.js is the entry point. Which
+ * means adding one import edge can change esbuild's evaluation order enough to construct
+ * a class before its own definition has run, and the bundle throws on load:
+ *
+ *     Uncaught TypeError: ee is not a constructor
+ *
+ * The page is then blank and every global the game exposes is undefined. Nothing in a
+ * source-reading check can see it, because the fault is in the order the ARTEFACT
+ * evaluates, and `node build.js` succeeds - esbuild has no complaint about a cycle it
+ * resolved. dist/bundle.js is committed, so a bundle in that state ships.
+ *
+ * So this imports the bundle with the browser globals stubbed just far enough to get
+ * through module evaluation. It deliberately does NOT try to run the game: once the
+ * modules have evaluated, main.js has started its timers and the point is already made.
+ *
+ * What it catches: a cycle-ordering fault, a missing import esbuild left as a runtime
+ * global, a syntax or TDZ error in any module. What it cannot: anything needing a real
+ * DOM, which is everything after the modules have loaded.
+ *
+ * No dependencies and no package.json - only node builtins.
+ *
+ * Run with: node tests/bundle-loads.mjs
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repo_root = path.resolve(import.meta.dirname, "..");
+const bundle = path.join(repo_root, "dist", "bundle.js");
+
+if (!fs.existsSync(bundle)) {
+    console.error("[check-bundle] dist/bundle.js is missing - run node build.js first.");
+    process.exit(1);
+}
+
+/**
+ * A value that answers to anything: property reads, calls, construction, iteration.
+ * Enough for module-scope DOM lookups, which is all this needs to get past.
+ */
+function anything() {
+    return new Proxy(function () {}, {
+        get(target, key) {
+            if (key === Symbol.toPrimitive || key === "toString") return () => "";
+            if (key === Symbol.iterator) return function* () {};
+            if (key === "length") return 0;
+            return anything();
+        },
+        set: () => true,
+        has: () => true,
+        apply: () => anything(),
+        construct: () => anything(),
+    });
+}
+
+globalThis.window = globalThis;
+globalThis.document = anything();
+globalThis.localStorage = { getItem: () => null, setItem() {}, removeItem() {} };
+globalThis.Audio = function () { return anything(); };
+globalThis.requestAnimationFrame = () => 0;
+globalThis.matchMedia = () => ({ matches: false, addEventListener() {} });
+globalThis.getComputedStyle = () => anything();
+globalThis.location = {
+    host: "localhost", pathname: "/", href: "http://localhost/",
+    protocol: "http:", search: "", hash: "", reload() {},
+};
+globalThis.history = { replaceState() {}, pushState() {} };
+globalThis.alert = () => {};
+globalThis.prompt = () => null;
+globalThis.confirm = () => false;
+globalThis.fetch = () => Promise.resolve({ ok: false, text: () => Promise.resolve("") });
+//navigator is a getter-only global in Node.
+try {
+    Object.defineProperty(globalThis, "navigator", {
+        value: { language: "en" }, configurable: true,
+    });
+} catch {}
+
+/*
+    The import runs in a child process. Getting through module evaluation means main.js
+    has started its timers, and nothing then makes the process exit - so the parent gives
+    the child a window, kills it, and reads the verdict off what it printed. A load-time
+    throw surfaces in well under a second; silence for the whole window is a pass.
+*/
+const EVALUATION_WINDOW_MS = 12000;
+
+if (process.argv[2] === "--child") {
+    /*
+        Copied to a .mjs path before importing. Node decides a .js file's module kind from
+        the nearest package.json, and this repo has none - so dist/bundle.js would be
+        treated as CommonJS and fail on the first piece of ESM syntax with a SyntaxError,
+        which looks exactly like the fault this test exists to find. The extension settles
+        it.
+    */
+    const as_module = path.join(os.tmpdir(), `bundle-check-${process.pid}.mjs`);
+    fs.copyFileSync(bundle, as_module);
+    process.on("exit", () => { try { fs.unlinkSync(as_module); } catch {} });
+
+    import(pathToFileURL(as_module).href).catch(problem => {
+        console.error(`THREW ${problem.name}: ${problem.message}`);
+        process.exit(1);
+    });
+} else {
+    const { spawn } = await import("node:child_process");
+    const child = spawn(process.execPath, [import.meta.filename, "--child"], {
+        stdio: ["ignore", "inherit", "pipe"],
+    });
+
+    let stderr = "";
+    child.stderr.on("data", chunk => { stderr += chunk; });
+
+    const verdict = await new Promise(resolve => {
+        const timer = setTimeout(() => {
+            child.kill();
+            resolve({ ok: true });
+        }, EVALUATION_WINDOW_MS);
+
+        child.on("exit", code => {
+            clearTimeout(timer);
+            resolve({ ok: code === 0 && !stderr.includes("THREW"), code });
+        });
+    });
+
+    if (!verdict.ok) {
+        const reported = stderr.trim().replace(/^[\s\S]*?THREW /, "");
+        console.error(`[check-bundle] the bundle threw while evaluating: ${reported}`);
+        console.error("[check-bundle] this is a load-time fault - the game would show a blank page.");
+        process.exit(1);
+    }
+
+    console.log("[check-bundle] the bundle evaluates without throwing.");
+}


### PR DESCRIPTION
# Fourteen fixes found while working from a fork

Every commit here is written against this repo's own code and style, and every one is a
fault I could measure rather than suspect. Nothing from my fork's own direction comes
with them — no translation layer, no content, no refactor of yours undone. Each commit
stands alone, so any of them can be dropped without touching the rest.

I found them by building a check suite in a fork and pointing it at this tree. Where a
finding turned out to need an authorial decision rather than a fix, I left the decision
to you and say so below.

---

## Combat and equipment

**`fd05869` Roll evasion when the shield does not block, so a weak shield is not a
downgrade.** The evasion roll sits in the `else` of the has-a-shield check, so equipping a
shield replaces evasion with blocking rather than adding to it. A low-block shield
therefore makes a character strictly worse at surviving, which is the opposite of what
the item says it does. Reported by a player who noticed they lived longer with the
off-hand slot empty.

**`e0578d1` Stop handing out a free point of defence per enemy tag.**

```js
defense_modifier += modifier_to_defense || 1;
```

`|| 1` is the identity for the multiplication two lines above, not for a sum. Most skills
return no `modifier_to_defense`, so every matched enemy tag silently granted a whole point
of defence.

---

## Items and names

**`5f36268` Store `material_id` and `armor_piece` on components, so generated names can
assemble.** `ItemComponent` never keeps the material it was made from, so a generated
equippable name has nothing to assemble from. In my fork this showed as 75 of 85 armour
names falling back to the raw English; here it is latent, and it is the same missing
field either way.

**`1e621cf` Name the cooked potato after itself.** The cooked item is named `Potato`, so
the raw and the cooked are indistinguishable in the inventory.

**`b373c83` Fix a reward's quality never reaching the item.**

```js
item = item_templates[rewards.items[i].item];
item.quality = rewards.items[i].quality;
character.addToInventory([{item_key: item.getInventoryKey(), count}]);
```

`getInventoryKey()` caches into `this.inventory_key`, and a template's key is cached long
before any reward is granted — so the stamp never reaches the key, and the key is what
the inventory is addressed by. Measured against your own accessors: the five starter
weapons in `data/dialogues.js` ask for quality 50 and arrive at 100, values 157/200/290
against the 79/100/144 they were priced at. The stamp does land on the shared template,
where `getBaseValue`'s `quality || this.quality || 100` reads it afterwards. Fixed with
the call `components/inventory_component.js` already makes for the `item_id` form.

---

## Conditions and actions

**`1130b7b` Fix the three faults in the new `location_clears` and `quests_*` conditions.**
An unguarded division (your own `//error here` is on the line), `.is_finished` where only
`isFinished()` exists, and a bare `quests` reference in a file that deliberately does not
import it.

**`9492add` Stop an item-consuming action from throwing, and an empty failure list from
showing nothing.** `action.success_conditions[0]` is `undefined[0]` since the conditions
moved onto the component; and a failure line is picked as
`list[Math.floor(list.length * Math.random())]`, which for an empty list is `undefined`.

**`6904425` Fix a doubled word in the gaze action's text.** "make make out".

---

## Display

**`d1971e0` Stop handing the starred-stances bar the wrong object.**
`update_displayed_stance_list` takes a third argument, `fav_stances`, whose only use in
the whole function is to be passed to `update_displayed_faved_stances` — which indexes it
as the stance registry. All three callers pass `faved_stances`, a map of id to `true`, so
every entry in the quick-select bar is named `undefined` as soon as one stance is starred,
and the sort below it reads `.stamina_cost` off `true`. Its own guard cannot catch that,
because `true` is truthy. `display.js` already imports `faved_stances`, so the argument
was never needed and the parameter is removed rather than corrected.

**`a7244f3` Make the anthology and bestiary actually sort.** The anthology comparator
subtracts strings, so it returns `NaN` and sorts nothing; the bestiary compares with `>`,
which is code-unit order. Both now use `localeCompare`.

**`746837a` Let a hero with a non-Latin-1 name export their save.** `btoa` throws on any
character above U+00FF, so a hero named Ayşe, José or Müller cannot export at all — and
the throw is uncaught, so the button simply does nothing.

---

## Build and tooling

**`ebe7507` Say something when a reward key is one nothing reads.** Motivated by a real
one: `data/locations.js` has `action:` on the lake-diving action where `process_rewards`
reads `rewards.actions`, so that half of the reward has never done anything — the
`skill_xp` beside it lands, which is exactly why it looks like it works. The inner field
would have to be `activity` too, since mining at Forest lake is a
`LocationGatheringActivity`.

**I have deliberately not changed that entry.** The vein it would open yields Silver ore,
whose only recipe is commented out, and your comment at `locations.js:934` says the reward
"doesn't really have any uses yet". Which key it should become, and whether silver opens
at all, is your call. What is not a judgement call is that a misspelled key should be
silent. Verified across all 249 reward objects in the content: exactly one warning fires,
the one above.

**`ceecd4c` Exit non-zero when the build cannot stamp the version.** `build.js` writes the
bundle, then rewrites `index.html`'s `?version=`. If either regex misses it prints in red
and returns — exit 0. So a new `dist/bundle.js` sits on disk while `index.html` still asks
for the old version, which is a bundle no browser will fetch, reported as a successful
build. `dist/` is committed, so that state ships.

**`c8b8e79` Add a check that the built bundle actually loads.** Optional, and the one
commit here that adds rather than fixes. The imports in `src/` are circular by design and
that cycle only resolves in a browser, so adding one import edge can change esbuild's
evaluation order enough to construct a class before its own definition has run:

```
Uncaught TypeError: ee is not a constructor
```

The page is then blank and every global is undefined. Nothing that reads source can see
it — the fault is in the order the artefact evaluates — and `node build.js` succeeds,
because esbuild has no complaint about a cycle it resolved. This cost me a shipped
release. `node tests/bundle-loads.mjs`, no dependencies, no `package.json`, only node
builtins. Negative-tested both ways.

---

## Two things I found and did not touch

Both need an authorial decision, so they are reports rather than commits.

1. **The gaze action declares a success text with `success_chances: [0]`.** Either the
   chance or the text is wrong; which one is a design question. It also has two endings no
   player can reach.
2. **The `action:` reward key above**, and with it whether the silver chain should open.

## One thing that looked like a finding and was not

My check for "declares a `conditional_loss` text but has no conditions" fires 21 times on
this tree, and every one is a false positive: it looks for a field named `conditions`,
and yours is `success_conditions`. Worth saying so that the number does not get repeated
as if it meant something.
