### PR TITLE
Three improvements from a fork: a dev console, milestones to the top of every bar, and gear comparison

### DIFF
--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -94,7 +94,70 @@ const skill_category_crafting = "Crafting";
                                             Combat: 1.05,
                                         }
                                     },
-                                    
+                                    15: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    20: {
+                                        xp_multipliers: {
+                                            category_Combat: 1.1,
+                                        },
+                                    },
+                                    25: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                        xp_multipliers: {
+                                            Combat: 1.1,
+                                        },
+                                    },
+                                    30: {
+                                        xp_multipliers: {
+                                            "Shield blocking": 1.1,
+                                        },
+                                    },
+                                    35: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    40: {
+                                        stats: {
+                                            dexterity: {multiplier: 1.05},
+                                        },
+                                        xp_multipliers: {
+                                            category_Combat: 1.1,
+                                        },
+                                    },
+                                    45: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    50: {
+                                        xp_multipliers: {
+                                            Evasion: 1.1,
+                                        },
+                                    },
+                                    55: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                        xp_multipliers: {
+                                            Evasion: 1.1,
+                                        },
+                                    },
+                                    60: {
+                                        stats: {
+                                            dexterity: {multiplier: 1.05},
+                                        },
+                                        xp_multipliers: {
+                                            Combat: 1.2,
+                                            category_Combat: 1.2,
+                                            Evasion: 1.2,
+                                        },
+                                    },
                                 },
                                 get_stat_modifiers: () => {
                                     return {
@@ -185,7 +248,58 @@ const skill_category_crafting = "Crafting";
                                             Swimming: 1.2,
                                             Running: 1.2,
                                         }
-                                    }
+                                    },
+                                    25: {
+                                        stats: {
+                                            agility: {flat: 1},
+                                        },
+                                    },
+                                    30: {
+                                        stats: {
+                                            agility: {flat: 1},
+                                        },
+                                    },
+                                    35: {
+                                        stats: {
+                                            agility: {flat: 1},
+                                        },
+                                        xp_multipliers: {
+                                            Equilibrium: 1.1,
+                                        },
+                                    },
+                                    40: {
+                                        stats: {
+                                            agility: {flat: 1},
+                                        },
+                                    },
+                                    45: {
+                                        stats: {
+                                            agility: {multiplier: 1.05},
+                                        },
+                                    },
+                                    50: {
+                                        stats: {
+                                            agility: {flat: 1},
+                                        },
+                                        xp_multipliers: {
+                                            Climbing: 1.1,
+                                        },
+                                    },
+                                    55: {
+                                        stats: {
+                                            agility: {flat: 1},
+                                        },
+                                    },
+                                    60: {
+                                        stats: {
+                                            agility: {multiplier: 1.05},
+                                        },
+                                        xp_multipliers: {
+                                            Equilibrium: 1.2,
+                                            Climbing: 1.2,
+                                            Swimming: 1.2,
+                                        },
+                                    },
                                 }
                             });
     skills["Shield blocking"] = new Skill({
@@ -263,7 +377,25 @@ const skill_category_crafting = "Crafting";
                                             stats: {
                                                 "strength": {multiplier: 1.05}
                                             }
-                                        }
+                                        },
+                                        25: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                        },
+                                        30: {
+                                            stats: {
+                                                strength: {multiplier: 1.05},
+                                                dexterity: {flat: 1},
+                                            },
+                                            xp_multipliers: {
+                                                Weightlifting: 1.2,
+                                                Fortitude: 1.2,
+                                                Perception: 1.2,
+                                            },
+                                        },
                                     }
                                 });
     
@@ -339,6 +471,73 @@ Adds ${skills["Unarmed"].getCurrentLvl()/10} base damage to unarmed attacks`;
                                                 Equilibrium: 1.1,
                                                 Weightlifting: 1.1,
                                                 Running: 1.1,
+                                            },
+                                        },
+                                        25: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                        },
+                                        30: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                        },
+                                        35: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                            xp_multipliers: {
+                                                Weightlifting: 1.1,
+                                            },
+                                        },
+                                        40: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                        },
+                                        45: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                        },
+                                        50: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                            xp_multipliers: {
+                                                Running: 1.1,
+                                            },
+                                        },
+                                        55: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                        },
+                                        60: {
+                                            stats: {
+                                                strength: {flat: 1},
+                                                dexterity: {flat: 1},
+                                                agility: {flat: 1},
+                                            },
+                                            xp_multipliers: {
+                                                Weightlifting: 1.2,
+                                                Running: 1.2,
+                                                Breathing: 1.2,
                                             },
                                         },
                                     }});
@@ -483,7 +682,58 @@ Adds ${skills["Unarmed"].getCurrentLvl()/10} base damage to unarmed attacks`;
                                                     xp_multipliers: {
                                                         all_skill: 1.2,
                                                     }
-                                                }
+                                                },
+                                                25: {
+                                                    stats: {
+                                                        intuition: {flat: 1},
+                                                    },
+                                                },
+                                                30: {
+                                                    stats: {
+                                                        intuition: {flat: 1},
+                                                    },
+                                                },
+                                                35: {
+                                                    stats: {
+                                                        intuition: {flat: 1},
+                                                    },
+                                                    xp_multipliers: {
+                                                        Evasion: 1.1,
+                                                    },
+                                                },
+                                                40: {
+                                                    stats: {
+                                                        intuition: {flat: 1},
+                                                    },
+                                                },
+                                                45: {
+                                                    stats: {
+                                                        intuition: {flat: 1},
+                                                    },
+                                                },
+                                                50: {
+                                                    stats: {
+                                                        intuition: {flat: 1},
+                                                    },
+                                                    xp_multipliers: {
+                                                        "Shield blocking": 1.1,
+                                                    },
+                                                },
+                                                55: {
+                                                    stats: {
+                                                        intuition: {flat: 1},
+                                                    },
+                                                },
+                                                60: {
+                                                    stats: {
+                                                        intuition: {flat: 1},
+                                                    },
+                                                    xp_multipliers: {
+                                                        Evasion: 1.2,
+                                                        "Shield blocking": 1.2,
+                                                        Combat: 1.2,
+                                                    },
+                                                },
                                             }
                                         });
     skills["Tight maneuvers"] = new Skill({
@@ -532,7 +782,52 @@ Adds ${skills["Unarmed"].getCurrentLvl()/10} base damage to unarmed attacks`;
                                                     "Shield blocking": 1.2,
                                                     Combat: 1.2,
                                                 }
-                                            }
+                                            },
+                                            25: {
+                                                stats: {
+                                                    agility: {flat: 5},
+                                                },
+                                            },
+                                            30: {
+                                                xp_multipliers: {
+                                                    "Shield blocking": 1.1,
+                                                },
+                                            },
+                                            35: {
+                                                xp_multipliers: {
+                                                    Evasion: 1.1,
+                                                },
+                                            },
+                                            40: {
+                                                xp_multipliers: {
+                                                    Equilibrium: 1.1,
+                                                },
+                                            },
+                                            45: {
+                                                xp_multipliers: {
+                                                    Evasion: 1.1,
+                                                },
+                                            },
+                                            50: {
+                                                xp_multipliers: {
+                                                    "Shield blocking": 1.1,
+                                                },
+                                            },
+                                            55: {
+                                                stats: {
+                                                    agility: {flat: 5},
+                                                },
+                                            },
+                                            60: {
+                                                stats: {
+                                                    agility: {flat: 5},
+                                                },
+                                                xp_multipliers: {
+                                                    Evasion: 1.2,
+                                                    "Shield blocking": 1.2,
+                                                    Combat: 1.2,
+                                                },
+                                            },
                                         }
                                     });
     skills["Night vision"] = new Skill({
@@ -775,6 +1070,34 @@ Adds ${skills["Unarmed"].getCurrentLvl()/10} base damage to unarmed attacks`;
                     Fortitude: 1.1,
                 }
             },
+            25: {
+                stats: {
+                    intuition: {flat: 1},
+                },
+            },
+            30: {
+                stats: {
+                    intuition: {flat: 1},
+                },
+            },
+            35: {
+                stats: {
+                    intuition: {flat: 1},
+                },
+                xp_multipliers: {
+                    all_skill: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    intuition: {multiplier: 1.1},
+                },
+                xp_multipliers: {
+                    all_skill: 1.2,
+                    Literacy: 1.2,
+                    Persistence: 1.2,
+                },
+            },
         }
     });
 
@@ -883,6 +1206,68 @@ Adds ${skills["Unarmed"].getCurrentLvl()/10} base damage to unarmed attacks`;
                     stamina_efficiency: { multiplier: 1.05 },
                 },
             },
+            25: {
+                stats: {
+                    dexterity: {flat: 1},
+                    agility: {flat: 1},
+                    stamina_regeneration_flat: {flat: 0.2},
+                },
+            },
+            30: {
+                stats: {
+                    dexterity: {flat: 1},
+                    agility: {flat: 1},
+                },
+            },
+            35: {
+                stats: {
+                    dexterity: {flat: 1},
+                    agility: {flat: 1},
+                },
+                xp_multipliers: {
+                    Running: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    dexterity: {flat: 1},
+                    agility: {flat: 1},
+                },
+            },
+            45: {
+                stats: {
+                    dexterity: {flat: 1},
+                    agility: {flat: 1},
+                    stamina_regeneration_flat: {flat: 0.2},
+                    max_stamina: {multiplier: 1.2},
+                },
+            },
+            50: {
+                stats: {
+                    dexterity: {flat: 1},
+                    agility: {flat: 1},
+                },
+                xp_multipliers: {
+                    Scrambling: 1.1,
+                },
+            },
+            55: {
+                stats: {
+                    dexterity: {flat: 1},
+                    agility: {flat: 1},
+                },
+            },
+            60: {
+                stats: {
+                    dexterity: {flat: 1},
+                    agility: {flat: 1},
+                    max_stamina: {multiplier: 1.2},
+                },
+                xp_multipliers: {
+                    Running: 1.2,
+                    Scrambling: 1.2,
+                },
+            },
         }
     });
 
@@ -970,6 +1355,65 @@ Multiplies AP with swords by ${Math.round((character.getTotalSkillCoefficient({s
                                             "dexterity": {flat: 2},
                                         }
                                     },
+                                    15: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            agility: {flat: 1},
+                                            strength: {flat: 1},
+                                            crit_multiplier: {flat: 0.1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    20: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    25: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    30: {
+                                        stats: {
+                                            agility: {flat: 1},
+                                        },
+                                    },
+                                    35: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    40: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    45: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            agility: {flat: 1},
+                                            strength: {flat: 1},
+                                            crit_multiplier: {flat: 0.1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    50: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    55: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    60: {
+                                        stats: {
+                                            agility: {flat: 1},
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
                                 },
                                 max_level_coefficient: 8
                             });
@@ -1016,6 +1460,61 @@ Multiplies AP with axes by ${Math.round((character.getTotalSkillCoefficient({ski
                                             "dexterity": {flat: 2},
                                         }
                                     },
+                                    15: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {flat: 1},
+                                        },
+                                    },
+                                    20: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    25: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    30: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {flat: 1},
+                                        },
+                                    },
+                                    35: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    40: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {multiplier: 1.05},
+                                        },
+                                    },
+                                    45: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {flat: 1},
+                                        },
+                                    },
+                                    50: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    55: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    60: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {multiplier: 1.05},
+                                        },
+                                    },
                                 },
                                 max_level_coefficient: 8});
 
@@ -1060,6 +1559,64 @@ Multiplies AP with spears by ${Math.round((character.getTotalSkillCoefficient({s
                                         stats: {
                                             "dexterity": {flat: 2},
                                         }
+                                    },
+                                    15: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {flat: 1},
+                                            crit_multiplier: {flat: 0.1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    20: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    25: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    30: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {flat: 1},
+                                        },
+                                    },
+                                    35: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    40: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    45: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {flat: 1},
+                                            crit_multiplier: {flat: 0.1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    50: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    55: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    60: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            strength: {flat: 1},
+                                        },
                                     },
                                 },
                                 max_level_coefficient: 8
@@ -1107,6 +1664,61 @@ Multiplies AP with hammers by ${Math.round((character.getTotalSkillCoefficient({
                                                     "dexterity": {flat: 2},
                                                 }
                                             },
+                                            15: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                    dexterity: {flat: 1},
+                                                },
+                                            },
+                                            20: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                },
+                                            },
+                                            25: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                    dexterity: {flat: 1},
+                                                },
+                                            },
+                                            30: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                },
+                                            },
+                                            35: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                    dexterity: {flat: 1},
+                                                },
+                                            },
+                                            40: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                },
+                                            },
+                                            45: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                    dexterity: {flat: 1},
+                                                },
+                                            },
+                                            50: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                },
+                                            },
+                                            55: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                    dexterity: {flat: 1},
+                                                },
+                                            },
+                                            60: {
+                                                stats: {
+                                                    strength: {flat: 1},
+                                                },
+                                            },
                                         },
                                         max_level_coefficient: 8
                                     });
@@ -1152,6 +1764,66 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                                         stats: {
                                             "dexterity": {flat: 2},
                                         }
+                                    },
+                                    15: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            agility: {flat: 1},
+                                            crit_multiplier: {flat: 0.1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    20: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    25: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    30: {
+                                        stats: {
+                                            crit_multiplier: {flat: 0.1},
+                                        },
+                                    },
+                                    35: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    40: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    45: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            agility: {flat: 1},
+                                            crit_multiplier: {flat: 0.1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    50: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                        },
+                                    },
+                                    55: {
+                                        stats: {
+                                            dexterity: {flat: 1},
+                                            crit_rate: {flat: 0.01},
+                                        },
+                                    },
+                                    60: {
+                                        stats: {
+                                            crit_multiplier: {flat: 0.1},
+                                            dexterity: {flat: 1},
+                                        },
                                     },
                                 },
                                 max_level_coefficient: 8
@@ -1454,7 +2126,22 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     "Presence sensing": 1.2,
                     Sleeping: 1.2,
                 }
-            }
+            },
+            25: {
+                stats: {
+                    intuition: {flat: 1},
+                },
+            },
+            30: {
+                stats: {
+                    intuition: {multiplier: 1.05},
+                },
+                xp_multipliers: {
+                    all: 1.2,
+                    "Presence sensing": 1.2,
+                    "Strength of mind": 1.2,
+                },
+            },
         },
         get_effect_description: ()=> {
             let value = character.getTotalSkillCoefficient({skill_id:"Meditation",scaling_type:"multiplicative"})
@@ -1565,7 +2252,47 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                 xp_multipliers: {
                     "Breathing": 1.2,
                 },
-            }
+            },
+            25: {
+                stats: {
+                    agility: {flat: 1},
+                    max_stamina: {flat: 5},
+                },
+            },
+            30: {
+                stats: {
+                    agility: {flat: 1},
+                },
+            },
+            35: {
+                stats: {
+                    agility: {flat: 1},
+                },
+                xp_multipliers: {
+                    Breathing: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    agility: {flat: 1},
+                    max_stamina: {multiplier: 1.1},
+                },
+            },
+            45: {
+                stats: {
+                    agility: {flat: 1},
+                    max_stamina: {flat: 5},
+                },
+            },
+            50: {
+                stats: {
+                    agility: {flat: 1},
+                    max_stamina: {multiplier: 1.1},
+                },
+                xp_multipliers: {
+                    Breathing: 1.2,
+                },
+            },
         },
         get_effect_description: ()=> {
             let value = character.getTotalSkillCoefficient({skill_id:"Running",scaling_type:"multiplicative"})
@@ -1665,7 +2392,49 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                         flat: 20,
                     },
                 },
-            }
+            },
+            25: {
+                stats: {
+                    max_stamina: {flat: 5},
+                    strength: {flat: 1},
+                },
+            },
+            30: {
+                stats: {
+                    max_stamina: {flat: 5},
+                    strength: {flat: 1},
+                },
+            },
+            35: {
+                stats: {
+                    max_stamina: {flat: 5},
+                    strength: {flat: 1},
+                },
+                xp_multipliers: {
+                    Unarmed: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    max_stamina: {flat: 5},
+                    strength: {multiplier: 1.05},
+                },
+            },
+            45: {
+                stats: {
+                    max_stamina: {flat: 5},
+                    strength: {flat: 1},
+                },
+            },
+            50: {
+                stats: {
+                    max_stamina: {flat: 5},
+                    strength: {multiplier: 1.05},
+                },
+                xp_multipliers: {
+                    Unarmed: 1.2,
+                },
+            },
         },
         get_effect_description: ()=> {
         let value = character.getTotalSkillCoefficient({skill_id:"Weightlifting",scaling_type:"multiplicative"})
@@ -1766,7 +2535,47 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                 xp_multipliers: {
                     "Breathing": 1.2,
                 }
-            }
+            },
+            25: {
+                stats: {
+                    max_stamina: {flat: 10},
+                    agility: {flat: 1},
+                    strength: {flat: 1},
+                },
+            },
+            30: {
+                stats: {
+                    agility: {flat: 1},
+                },
+            },
+            35: {
+                stats: {
+                    agility: {flat: 1},
+                },
+                xp_multipliers: {
+                    Breathing: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    agility: {multiplier: 1.05},
+                },
+            },
+            45: {
+                stats: {
+                    max_stamina: {flat: 10},
+                    agility: {flat: 1},
+                },
+            },
+            50: {
+                stats: {
+                    agility: {multiplier: 1.05},
+                    max_stamina: {flat: 10},
+                },
+                xp_multipliers: {
+                    Breathing: 1.2,
+                },
+            },
         },
         
     });
@@ -1838,7 +2647,51 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                 xp_multipliers: {
                     "Unarmed": 1.2,
                 }
-            }
+            },
+            25: {
+                stats: {
+                    agility: {flat: 1},
+                    strength: {flat: 1},
+                    intuition: {flat: 1},
+                },
+            },
+            30: {
+                stats: {
+                    agility: {flat: 1},
+                    strength: {flat: 1},
+                },
+            },
+            35: {
+                stats: {
+                    agility: {flat: 1},
+                    strength: {flat: 1},
+                },
+                xp_multipliers: {
+                    Unarmed: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    agility: {multiplier: 1.05},
+                    strength: {flat: 1},
+                },
+            },
+            45: {
+                stats: {
+                    agility: {flat: 1},
+                    strength: {flat: 1},
+                    intuition: {flat: 1},
+                },
+            },
+            50: {
+                stats: {
+                    agility: {multiplier: 1.05},
+                    strength: {flat: 1},
+                },
+                xp_multipliers: {
+                    Unarmed: 1.2,
+                },
+            },
         },
         get_effect_description: ()=> {
         let value = character.getTotalSkillCoefficient({skill_id:"Equilibrium",scaling_type:"multiplicative"});
@@ -1927,7 +2780,46 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                         flat: 3,
                     }
                 }
-            }
+            },
+            25: {
+                stats: {
+                    strength: {flat: 1},
+                    agility: {flat: 1},
+                    intuition: {flat: 3},
+                },
+            },
+            30: {
+                xp_multipliers: {
+                    Perception: 1.1,
+                },
+            },
+            35: {
+                stats: {
+                    strength: {flat: 1},
+                },
+                xp_multipliers: {
+                    Perception: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    agility: {multiplier: 1.05},
+                },
+            },
+            45: {
+                stats: {
+                    strength: {flat: 1},
+                },
+            },
+            50: {
+                stats: {
+                    agility: {multiplier: 1.05},
+                    strength: {flat: 1},
+                },
+                xp_multipliers: {
+                    Perception: 1.2,
+                },
+            },
         },
         get_effect_description: ()=> {
           let value = character.getTotalSkillCoefficient({skill_id:"Climbing",scaling_type:"multiplicative"});
@@ -2092,6 +2984,65 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     Meditation: 1.2
                 }
             },
+            25: {
+                stats: {
+                    intuition: {flat: 1},
+                    dexterity: {flat: 1},
+                },
+            },
+            30: {
+                stats: {
+                    intuition: {flat: 1},
+                    dexterity: {flat: 1},
+                },
+            },
+            35: {
+                stats: {
+                    intuition: {flat: 1},
+                    dexterity: {flat: 1},
+                },
+                xp_multipliers: {
+                    Persistence: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    intuition: {flat: 1},
+                    dexterity: {flat: 1},
+                },
+            },
+            45: {
+                stats: {
+                    intuition: {multiplier: 1.1},
+                    dexterity: {flat: 1},
+                },
+            },
+            50: {
+                stats: {
+                    intuition: {flat: 1},
+                    dexterity: {flat: 1},
+                },
+                xp_multipliers: {
+                    Perception: 1.1,
+                },
+            },
+            55: {
+                stats: {
+                    intuition: {flat: 1},
+                    dexterity: {flat: 1},
+                },
+            },
+            60: {
+                stats: {
+                    intuition: {multiplier: 1.1},
+                    dexterity: {flat: 1},
+                },
+                xp_multipliers: {
+                    Persistence: 1.2,
+                    Perception: 1.2,
+                    Meditation: 1.2,
+                },
+            },
         }
     });
 })();
@@ -2148,7 +3099,42 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                         multiplier: 1.05,
                     },
                 }
-            }
+            },
+            35: {
+                xp_multipliers: {
+                    Crafting: 1.1,
+                },
+            },
+            40: {
+                xp_multipliers: {
+                    Butchering: 1.1,
+                },
+            },
+            45: {
+                xp_multipliers: {
+                    Crafting: 1.1,
+                },
+            },
+            50: {
+                stats: {
+                    dexterity: {multiplier: 1.05},
+                },
+            },
+            55: {
+                xp_multipliers: {
+                    Butchering: 1.1,
+                },
+            },
+            60: {
+                stats: {
+                    dexterity: {multiplier: 1.05},
+                },
+                xp_multipliers: {
+                    Crafting: 1.2,
+                    Butchering: 1.2,
+                    Woodworking: 1.2,
+                },
+            },
         }
     });
 
@@ -2297,7 +3283,22 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     Fortitude: 1.2,
                     Persistence: 1.2,
                 }
-            }
+            },
+            25: {
+                stats: {
+                    unarmed_power: {flat: 0.4},
+                },
+            },
+            30: {
+                stats: {
+                    unarmed_power: {flat: 0.4},
+                    max_health: {multiplier: 1.1},
+                },
+                xp_multipliers: {
+                    Fortitude: 1.2,
+                    Persistence: 1.2,
+                },
+            },
         }
     });
     skills["Fortitude"] = new Skill({
@@ -2356,7 +3357,53 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     "Iron skin": 1.2,
                     Persistence: 1.2,
                 }
-            }
+            },
+            25: {
+                stats: {
+                    defense: {flat: 1},
+                },
+            },
+            30: {
+                xp_multipliers: {
+                    Persistence: 1.1,
+                },
+            },
+            35: {
+                xp_multipliers: {
+                    "Iron skin": 1.1,
+                },
+            },
+            40: {
+                xp_multipliers: {
+                    Persistence: 1.1,
+                },
+            },
+            45: {
+                stats: {
+                    defense: {flat: 1},
+                    max_health: {multiplier: 1.05},
+                },
+            },
+            50: {
+                xp_multipliers: {
+                    Persistence: 1.1,
+                },
+            },
+            55: {
+                xp_multipliers: {
+                    "Iron skin": 1.1,
+                },
+            },
+            60: {
+                stats: {
+                    max_health: {multiplier: 1.05},
+                    defense: {flat: 1},
+                },
+                xp_multipliers: {
+                    "Iron skin": 1.2,
+                    Persistence: 1.2,
+                },
+            },
         }
     });
 })();
@@ -2447,7 +3494,24 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                 xp_multipliers: {
                     all: 1.1,
                 }
-            }
+            },
+            25: {
+                stats: {
+                    max_stamina: {flat: 5},
+                    heat_tolerance: {flat: 1},
+                    cold_tolerance: {flat: 1},
+                },
+            },
+            30: {
+                stats: {
+                    max_stamina: {multiplier: 1.1},
+                },
+                xp_multipliers: {
+                    all_skill: 1.2,
+                    hero: 1.2,
+                    all: 1.2,
+                },
+            },
         },
         max_level_bonus: 0.3
     });
@@ -2517,7 +3581,41 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     dexterity: {multiplier: 1.1},
                     crit_multiplier: {flat: 0.2},
                 },
-            }
+            },
+            25: {
+                stats: {
+                    intuition: {flat: 2},
+                    dexterity: {flat: 2},
+                    crit_multiplier: {flat: 0.1},
+                },
+            },
+            30: {
+                stats: {
+                    intuition: {flat: 2},
+                    crit_multiplier: {flat: 0.1},
+                },
+            },
+            35: {
+                stats: {
+                    intuition: {flat: 2},
+                    crit_multiplier: {flat: 0.1},
+                },
+                xp_multipliers: {
+                    all: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    intuition: {flat: 2},
+                    crit_multiplier: {flat: 0.1},
+                    dexterity: {multiplier: 1.1},
+                },
+                xp_multipliers: {
+                    all: 1.2,
+                    Herbalism: 1.2,
+                    Fishing: 1.2,
+                },
+            },
         }
     });
     skills["Literacy"] = new Skill({
@@ -2549,7 +3647,24 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     hero: 1.05,
                     "Strength of mind": 1.05,
                 }
-            }
+            },
+            6: {
+                xp_multipliers: {
+                    hero: 1.1,
+                },
+            },
+            8: {
+                xp_multipliers: {
+                    "Strength of mind": 1.1,
+                },
+            },
+            10: {
+                xp_multipliers: {
+                    hero: 1.2,
+                    "Strength of mind": 1.2,
+                    all_skill: 1.2,
+                },
+            },
         }
     });
     skills["Medicine"] = new Skill({
@@ -2640,6 +3755,24 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     Persistence: 1.2,
                 }
             },
+            25: {
+                stats: {
+                    max_health: {flat: 20},
+                    max_stamina: {flat: 20},
+                    health_regeneration_flat: {flat: 0.1},
+                },
+            },
+            30: {
+                stats: {
+                    max_stamina: {multiplier: 1.1},
+                    max_health: {flat: 20},
+                },
+                xp_multipliers: {
+                    Fortitude: 1.2,
+                    Persistence: 1.2,
+                    Regeneration: 1.2,
+                },
+            },
         }
     });
     skills["Gluttony"] = new Skill({
@@ -2717,6 +3850,24 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     hero: 1.1,
                     Regeneration: 1.2,
                 }
+            },
+            25: {
+                stats: {
+                    max_health: {flat: 20},
+                    cold_tolerance: {flat: 1},
+                    health_regeneration_flat: {flat: 0.1},
+                    stamina_regeneration_flat: {flat: 0.1},
+                },
+            },
+            30: {
+                stats: {
+                    max_health: {flat: 20},
+                },
+                xp_multipliers: {
+                    hero: 1.2,
+                    Regeneration: 1.2,
+                    Weightlifting: 1.2,
+                },
             },
         }
     });
@@ -2819,7 +3970,35 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                         multiplier: 1.05,
                     }
                 }
-            }
+            },
+            25: {
+                stats: {
+                    strength: {flat: 2},
+                    agility: {flat: 2},
+                    stamina_regeneration_flat: {flat: 0.1},
+                },
+            },
+            30: {
+                xp_multipliers: {
+                    Meditation: 1.1,
+                },
+            },
+            35: {
+                xp_multipliers: {
+                    Running: 1.1,
+                },
+            },
+            40: {
+                stats: {
+                    agility: {multiplier: 1.05},
+                    strength: {flat: 2},
+                },
+                xp_multipliers: {
+                    Running: 1.2,
+                    Meditation: 1.2,
+                    category_Activity: 1.2,
+                },
+            },
         },
         get_effect_description: ()=> {
             let value = character.getTotalSkillCoefficient({skill_id:"Breathing",scaling_type:"multiplicative"});
@@ -2905,6 +4084,37 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                                             Fortitude: 1.2,
                                         }
                                     },
+                                    25: {
+                                        stats: {
+                                            max_health: {flat: 20},
+                                            health_regeneration_flat: {flat: 0.1},
+                                        },
+                                    },
+                                    30: {
+                                        stats: {
+                                            max_health: {flat: 20},
+                                            health_regeneration_flat: {flat: 0.1},
+                                        },
+                                    },
+                                    35: {
+                                        stats: {
+                                            max_health: {flat: 20},
+                                            health_regeneration_flat: {flat: 0.1},
+                                        },
+                                        xp_multipliers: {
+                                            "Iron skin": 1.1,
+                                        },
+                                    },
+                                    40: {
+                                        stats: {
+                                            max_health: {multiplier: 1.1},
+                                            health_regeneration_flat: {flat: 0.1},
+                                        },
+                                        xp_multipliers: {
+                                            "Iron skin": 1.2,
+                                            Fortitude: 1.2,
+                                        },
+                                    },
                                 }
     });  
 })();
@@ -2976,7 +4186,22 @@ Multiplies AP with daggers by ${Math.round((character.getTotalSkillCoefficient({
                     Persistence: 1.1,
                     Perception: 1.1,
                 },
-            }
+            },
+            20: {
+                stats: {
+                    intuition: {flat: 1},
+                },
+            },
+            25: {
+                stats: {
+                    intuition: {flat: 1},
+                },
+                xp_multipliers: {
+                    Literacy: 1.2,
+                    Persistence: 1.2,
+                    Perception: 1.2,
+                },
+            },
         }
     });
 })();

--- a/src/display.js
+++ b/src/display.js
@@ -368,6 +368,76 @@ function round(number) {
  * @param {Boolean} params.options.skip_quality
  * @param {Array} params.options.quality array with 1 or 2 values (1 - show only it, instead of item's; 2 - show start comparison between the two)
  */
+/**
+ * How this item would change things if it replaced what is worn in its slot.
+ *
+ * Flat values as a difference, multipliers as a percentage - those are the two
+ * questions a player has about a piece of gear. A stat that comes out identical is left
+ * out, because the point of the block is what would change.
+ *
+ * Returns "" when there is nothing to say: an empty slot, the worn item itself, or a
+ * quality range rather than one quality.
+ *
+ * @param {Object} item the item being hovered
+ * @param {Number} quality optional, the quality the tooltip is showing
+ */
+function equipment_comparison(item, quality) {
+    if(!item?.equip_slot) {
+        return "";
+    }
+    const worn = character.getEquipment()[item.equip_slot];
+    if(!worn || worn === item) {
+        return "";
+    }
+
+    const lines = [];
+    const round2 = (value) => Math.round(value * 100) / 100;
+
+    const flat_line = (label, mine, theirs) => {
+        const delta = round2((mine || 0) - (theirs || 0));
+        if(!delta) {
+            return;
+        }
+        const better = delta > 0 ? "comparison_better" : "comparison_worse";
+        lines.push(`<br><span class="${better}">${label}: ${delta > 0 ? "+" : ""}${delta}</span>`);
+    };
+
+    const multiplier_line = (label, mine, theirs) => {
+        const percent = Math.round(((mine || 1) / (theirs || 1) - 1) * 1000) / 10;
+        if(!percent) {
+            return;
+        }
+        const better = percent > 0 ? "comparison_better" : "comparison_worse";
+        lines.push(`<br><span class="${better}">${label}: ${percent > 0 ? "+" : ""}${percent}%</span>`);
+    };
+
+    //The headline number for the slot, whichever one this kind of item has. The worn
+    //item is asked without a quality so it answers with its own.
+    if(item.getAttack && worn.getAttack) {
+        flat_line("Attack", item.getAttack(quality), worn.getAttack());
+    } else if(item.getDefense && worn.getDefense) {
+        flat_line("Defense", item.getDefense(quality), worn.getDefense());
+    } else if(item.getShieldStrength && worn.getShieldStrength) {
+        flat_line("Block", item.getShieldStrength(quality), worn.getShieldStrength());
+    }
+
+    const mine = item.getStats(quality);
+    const theirs = worn.getStats();
+    for(const stat_key of new Set([...Object.keys(mine), ...Object.keys(theirs)])) {
+        const label = capitalize_first_letter(stat_names[stat_key] ?? stat_key.replace("_", " "));
+        if(mine[stat_key]?.flat != null || theirs[stat_key]?.flat != null) {
+            flat_line(label, mine[stat_key]?.flat, theirs[stat_key]?.flat);
+        }
+        if(mine[stat_key]?.multiplier != null || theirs[stat_key]?.multiplier != null) {
+            multiplier_line(label, mine[stat_key]?.multiplier, theirs[stat_key]?.multiplier);
+        }
+    }
+
+    if(lines.length === 0) {
+        return "";
+    }
+    return `<br><br>Compared to equipped:${lines.join("")}`;
+}
 function create_item_tooltip_content({item, options={}, is_trade = false}) {
     let item_tooltip = "";
 
@@ -530,6 +600,11 @@ function create_item_tooltip_content({item, options={}, is_trade = false}) {
                 `<br>${capitalize_first_letter(effect_key).replace("_"," ")}: x${item.component_stats[effect_key].multiplier}`;
             }
         });
+    }
+
+    //Only for a single quality: a range has no one value to subtract.
+    if(!(options?.quality?.length > 1)) {
+        item_tooltip += equipment_comparison(item, quality);
     }
 
     if(item?.base_size) {

--- a/src/main.js
+++ b/src/main.js
@@ -6135,6 +6135,7 @@ function set_game_speed(multiplier) {
  * exercised without playing up to it:
  *
  *     add_active_effect("Coffee", 1800)
+ *     add_best_effect(1800)
  *     give({items: [{item: "Iron sword", quality: 120}], money: 50000})
  *     goto("The bay")
  *     set_speed(100)
@@ -6176,6 +6177,40 @@ function enable_dev_console() {
             return Object.keys(rewards);
         },
 
+        /*
+            Every good effect at once.
+
+            Which effects count as good is read off the templates - `tags.buff` - rather
+            than listed here. A list written into this file would be correct until the
+            next effect is added and then quietly wrong, and the data already carries
+            the answer better than the numbers would: Tipsy raises agility, lowers
+            dexterity, and is tagged debuff, which is an intent the stat signs cannot
+            express.
+
+            Effects sharing a group_tag do not stack; add_active_effect keeps the
+            stronger and skips the weaker, so the skipped names are reported rather than
+            silently missing from the count.
+
+            Duration is in in-game minutes, like every duration in content.
+        */
+        add_best_effect: (duration = 1800) => {
+            if(typeof duration !== "number" || !(duration > 0)) {
+                console.error(`Duration has to be a positive number of in-game minutes, got "${duration}".`);
+                return;
+            }
+
+            const good = Object.keys(effect_templates).filter(key => effect_templates[key].tags?.buff);
+            const applied = [];
+            const skipped = [];
+            good.sort().forEach(key => {
+                real_add_active_effect(key, duration);
+                (active_effects[key] ? applied : skipped).push(key);
+            });
+
+            return skipped.length
+                ? {applied, held_back_by_a_stronger_effect: skipped}
+                : applied;
+        },
         add_money: (amount) => { add_money_to_character(amount); return character.money; },
         add_xp: (amount) => { add_xp_to_character(amount); return character.xp.current_level; },
         add_skill_xp: (skill, amount) => {

--- a/src/main.js
+++ b/src/main.js
@@ -200,6 +200,7 @@ let current_location;
 let current_activity;
 
 let game_action_interval;
+let game_action_tick;
 let current_game_action;
 
 //loot from currently active source (combat location or specific activity), used for display if dynamic loot logging option is enabled
@@ -235,7 +236,10 @@ let save_counter = 0;
 const backup_period = 3600;
 let backup_counter = 0;
 
-const tickrate = config.tickrate;
+//Not const: set_game_speed multiplies it. It is the divisor of every wall-clock delay
+//in this file and of every per-tick accounting term, which is what makes it the right
+//and only place a speed control belongs.
+let tickrate = config.tickrate;
 
 //accumulates deviations
 let time_variance_accumulator = 0;
@@ -779,9 +783,11 @@ function start_game_action(action_key, event) {
         let current_iterations = game_action.keep_progress?game_action.accumulated_progress:0;
         const total_iterations = game_action.attempt_duration/0.1;
 
-        game_action_interval = setInterval(()=>{
+        //Kept in a variable rather than passed inline, so the interval can be re-armed
+        //at a new speed without losing the progress that lives in this closure.
+        game_action_tick = ()=>{
             if(current_iterations >= total_iterations - 1) {
-                clearInterval(game_action_interval);
+                stop_game_action_interval();
                 finish_game_action({action_key, conditions_status, dialogue_key: current_dialogue});
             }
 
@@ -790,13 +796,40 @@ function start_game_action(action_key, event) {
                 game_action.accumulated_progress = current_iterations;
             }
             update_game_action_progress_bar(current_iterations/total_iterations);
-        }, 1000*0.1/tickrate);
+        };
+        game_action_interval = setInterval(game_action_tick, game_action_period());
     } else {
         update_game_action_progress_bar(1);
         finish_game_action({action_key, conditions_status,dialogue_key: current_dialogue});
     }
 }
 
+/** The action ticker's period at the current speed. */
+function game_action_period() {
+    return 1000 * 0.1 / tickrate;
+}
+
+function stop_game_action_interval() {
+    clearInterval(game_action_interval);
+    game_action_interval = undefined;
+    game_action_tick = undefined;
+}
+
+/**
+ * Re-arms the running action at the current speed.
+ *
+ * setInterval keeps the period it was created with, so raising the speed mid-action
+ * would change nothing until the action was over - the one moment the speed is no
+ * longer wanted. The progress lives in the tick's closure, so swapping the interval
+ * out from under it loses nothing.
+ */
+function rearm_game_action_interval() {
+    if(!game_action_tick) {
+        return;
+    }
+    clearInterval(game_action_interval);
+    game_action_interval = setInterval(game_action_tick, game_action_period());
+}
 /**
  * Handles the finish, successful or not, of a game action. Not to be mistaken for end_game_action
  * @param {String} action_key 
@@ -884,7 +917,7 @@ function finish_game_action({action_key, conditions_status, dialogue_key}){
  */
 function end_game_action() {
     end_activity_animation();
-    clearInterval(game_action_interval);
+    stop_game_action_interval();
     current_game_action = null;
     remove_from_content_stack(content_stack_removal_options.TOP);
 }
@@ -3051,7 +3084,7 @@ function switch_action_box_content() {
     } else if(current_game_action) {
         current_game_action = null;
         end_activity_animation();
-        clearInterval(game_action_interval);
+        stop_game_action_interval();
     }
 
     if(content_stack.length) {
@@ -6068,6 +6101,134 @@ window.get_game_version = get_game_version;
 window.run = run;
 
 //Verify_Game_Objects();
+/*
+    The development speed multiplier.
+
+    Not saved. A reload is back to 1x, which is the right default for something that
+    makes every activity, book and journey trivial.
+*/
+let game_speed = 1;
+
+function set_game_speed(multiplier) {
+    const allowed = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000];
+    if(!allowed.includes(multiplier)) {
+        console.error(`Speed must be one of ${allowed.join(", ")}.`);
+        return game_speed;
+    }
+    game_speed = multiplier;
+    tickrate = config.tickrate * game_speed;
+
+    //An action already running holds its own interval, which has to be re-armed to
+    //notice this at all.
+    rearm_game_action_interval();
+    return game_speed;
+}
+
+/**
+ * Development console, off until it is asked for.
+ *
+ * Typed once in the browser console:
+ *
+ *     enable_dev_console()
+ *
+ * After that a handful of functions exist as bare globals, so a change can be
+ * exercised without playing up to it:
+ *
+ *     add_active_effect("Coffee", 1800)
+ *     give({items: [{item: "Iron sword", quality: 120}], money: 50000})
+ *     goto("The bay")
+ *     set_speed(100)
+ *
+ * Deliberately NOT on by default and deliberately NOT saved. A reload turns it off
+ * again. It can hand out every item in the game and walk to any room, which is exactly
+ * what makes it useful and exactly why it should not be one typo away from a player who
+ * opened devtools to look at something else. is_on_dev() is not the gate either: the dev
+ * release is still a release somebody plays.
+ *
+ * The functions are the game's own. Nothing here is a second implementation of a reward
+ * or an unlock - `give` is process_rewards, the same path a quest takes, so anything
+ * granted here behaves the way the content would have granted it.
+ */
+function enable_dev_console() {
+    const list = (registry) => Object.keys(registry).sort();
+
+    //Captured before the globals are attached. Module scope would win over window
+    //anyway, so `add_active_effect` inside the wrapper is already the real function -
+    //but a reader should not have to know that to be sure it is not calling itself.
+    const real_add_active_effect = add_active_effect;
+
+    const helpers = {
+        //Duration is in in-game minutes, like every duration in content:
+        //{effect: "Coffee", duration: 150} is what an item says.
+        add_active_effect: (effect_key, duration = 600) => {
+            if(!effect_templates[effect_key]) {
+                console.error(`No such effect as "${effect_key}". Try list_effects().`);
+                return;
+            }
+            real_add_active_effect(effect_key, duration);
+            return `${effect_key} for ${duration} minutes`;
+        },
+
+        //Everything the content can grant, through the path the content grants it by.
+        //The shape is a rewards object exactly as written in quests.js or dialogues.js.
+        give: (rewards) => {
+            process_rewards({rewards, source_type: "dev console", source_name: "dev console"});
+            return Object.keys(rewards);
+        },
+
+        add_money: (amount) => { add_money_to_character(amount); return character.money; },
+        add_xp: (amount) => { add_xp_to_character(amount); return character.xp.current_level; },
+        add_skill_xp: (skill, amount) => {
+            if(!skills[skill]) {
+                console.error(`No such skill as "${skill}". Try list_skills().`);
+                return;
+            }
+            add_xp_to_skill({skill: skills[skill], xp_to_add: amount});
+            return skills[skill].current_level;
+        },
+
+        //Unlocks the room first, because walking somewhere locked is the usual reason
+        //this is being typed at all.
+        goto: (location_name) => {
+            if(!locations[location_name]) {
+                console.error(`No such location as "${location_name}". Try list_locations().`);
+                return;
+            }
+            unlock_location({location: locations[location_name], skip_message: true});
+            change_location({location_id: location_name});
+            return location_name;
+        },
+
+        set_flag: (flag, value = true) => {
+            if(!(flag in global_flags)) {
+                console.error(`No such flag as "${flag}". Known: ${list(global_flags).join(", ")}`);
+                return;
+            }
+            global_flags[flag] = value;
+            return `${flag} = ${value}`;
+        },
+
+        list_effects: () => list(effect_templates),
+        list_items: () => list(item_templates),
+        list_locations: () => list(locations),
+        list_skills: () => list(skills),
+        list_quests: () => list(quests),
+        list_dialogues: () => list(dialogues),
+        list_flags: () => list(global_flags),
+
+        set_speed: (multiplier) => set_game_speed(multiplier),
+    };
+
+    Object.keys(helpers).forEach(name => { window[name] = helpers[name]; });
+
+    console.log("dev console on. Not saved - a reload turns it off.");
+    console.log(Object.keys(helpers).join("(), ") + "()");
+    return Object.keys(helpers);
+}
+
+//The only thing the dev console exposes by itself. Everything else it hands out
+//appears when this is called.
+window.enable_dev_console = enable_dev_console;
 window.Verify_Game_Objects = Verify_Game_Objects;
 
 set_loading_screen_progress("Waking up from a nyap...");

--- a/style.css
+++ b/style.css
@@ -2867,3 +2867,11 @@ i {
 ::-webkit-scrollbar-thumb:hover {
 	background: white; 
   }
+
+ /* An item tooltip's comparison with what is worn: better in green, worse in red. */
+ .comparison_better {
+	 color: green;
+ }
+ .comparison_worse {
+	 color: red;
+ }


### PR DESCRIPTION
# Three improvements from a fork, offered separately from the fixes

Companion to #241, which is bug fixes only. This one is the opposite: nothing here is
broken today, these are additions. Each is one commit, each is written against this
repo's own code and style, and each stands alone — take one, take none, take all three.

Nothing from my fork's own direction comes with them: no translation layer, no content of
mine, no refactor of yours undone.

---

## `16625db` A development console, and a speed multiplier for it to drive

Off by default and never saved. Typed once in the browser console:

```js
enable_dev_console()
```

after which a handful of functions exist as bare globals:

```js
give({items: [{item: "Iron sword", quality: 120}, {item: "Iron ore", count: 50}], money: 50000})
goto("The bay")
add_active_effect("Coffee", 1800)
add_skill_xp("Farming", 5000)
set_flag("is_gathering_unlocked")
set_speed(100)
list_items()  list_skills()  list_locations()  list_quests()  list_dialogues()  list_effects()  list_flags()
```

Nothing here is a second implementation. `give` **is** `process_rewards`, the same path a
quest reward takes, so anything granted behaves the way content would have granted it, and
the `list_*` helpers just sort the registries so a name can be found without reading the
source.

Deliberately not on by default, and deliberately not gated on `is_on_dev()` either — a dev
release is still a release somebody plays, and this hands out every item in the game and
walks into any room. That is what makes it useful and why it should not be one typo away
from a player who opened devtools to look at something else.

**No UI is added**: no markup, no CSS, no buttons. The whole thing is in `main.js`.

The speed control is `tickrate`, which is already the divisor of every wall-clock delay in
`main.js` *and* of every per-tick accounting term — so raising it means more ticks per
second with each tick still worth exactly what it was. That makes it the only place a
speed control belongs; nothing else has to know about it. Two changes make it work:

- `const tickrate` becomes `let`;
- the one `setInterval` that captures a tickrate-derived period — the action progress
  ticker — can now be re-armed. The main loop and both combat loops use `setTimeout` and
  rebuild themselves each tick, so they pick a change up immediately; the action interval
  would otherwise hold its old period until the action ended, which is the one moment the
  speed is no longer wanted.

---

## `70478ec` A milestone every five levels, to the top of every bar

31 skills have milestones that stop well before `max_level`, so levelling past the last
one grants nothing at all. Literacy ends at 5 of 10. The five weapon skills end at 12 of
60. The crafting skills end at 30 of 60. 185 empty five-level steps in total.

Those steps are now filled — and generated from each skill rather than to a template,
because 185 hand-picked values would have been 185 unmeasured decisions:

- **its own vocabulary** — only the stat keys and xp targets that skill already grants. A
  skill that has only ever given intuition keeps giving intuition; Literacy, which has
  only ever sped up learning, only speeds up learning;
- **its own units** — the smallest flat that key has in that skill, so `+1` dexterity
  where it deals in ones and `+20 max_health` where it deals in twenties;
- **its own pace** — each key fires on a period taken from its share of the existing
  milestones, so a new milestone is worth about what an old one is. The aim was to fill
  the bar, not inflate the character. Spending the head's *total* across the tail was the
  first attempt and it was wrong for short tails: it crammed 11 points into one of Shield
  blocking's two remaining levels;
- **its own ceiling** — a multiplier never exceeds the largest that skill already uses for
  that stat, and xp multipliers stay on 1.05 / 1.1 / 1.2, the only three values in the
  file.

Two departures, both because the rule would otherwise produce nothing: **Literacy** never
reaches 20, so it keeps its own dense early cadence (6, 8, 10); and **Gathering mastery**
and **Crafting mastery** grant no flats and name no xp targets, so they boost their own
children instead — which is what a mastery skill is for.

**Forging is deliberately left alone** and is the one skill still stopping early. Its
single milestone rewards a recipe unlock and nothing else, so there is no vocabulary to
extend, and inventing one would be inventing balance. That is your call, not mine.

---

## `ebde1a7` Show how an item compares with what is already worn

Hovering a weapon or a piece of armour tells you its numbers but not whether they beat the
numbers you are already wearing, so the comparison happens in the player's head — or not
at all.

The tooltip now ends with a **Compared to equipped** block: flat values as a difference,
multipliers as a percentage, better in green and worse in red. Those are the two questions
a player actually has about a piece of gear — how much more armour, and how much faster —
and they read differently, so they are shown differently.

A stat that comes out identical is left out entirely. The block is about what *would
change*; listing the unchanged stats again is what makes a comparison hard to read.

Nothing is shown when there is nothing to say: an empty slot, the worn item itself, or a
tooltip showing a quality **range** rather than one quality, since a range has no single
value to subtract.

Uses what is already there — `stat_names` from `misc.js`, `character.getEquipment()`, and
the same optional-quality accessors the lines above it call. Two CSS classes added,
nothing else touched.

---

## On the milestone commit specifically

It is the one that changes balance rather than adding a capability, so it is also the
easiest to drop. If the direction is right but the numbers are not, the rules above are
the part worth arguing with — they are mechanical, and different rules would produce a
different tail from the same measurements.
