### PR TITLE
Two display fixes: the action name never reaches its button, and an animation that spins on nothing

### DIFF
--- a/src/display.js
+++ b/src/display.js
@@ -2558,7 +2558,20 @@ function create_location_choices({location, category, is_combat = false}) {
 
             location_action_div.appendChild(create_location_action_tooltip(location.actions[key]));
     
-            insert_HTML(location_action_div, `<i class="material-icons location_choice_icon">check_box_outline_blank</i> ` + location.actions[key].starting_text);
+            /*
+                action_name, not starting_text. The model sets
+                `action_name = data.action_name || data.starting_text`, so an action that
+                does not declare one is unchanged - but seven do, and their names never
+                reach the screen.
+
+                Three of those seven are the ant nests: "Search for ant nests", "Search
+                for second ant nest" and "Search for third ant nests" all draw the same
+                button, "Dig in search of red ant nests", because that is the
+                starting_text they share. The unlock message uses action_name, so the log
+                says Unlocked action "Search for second ant nest" and the player then
+                cannot find anything by that name.
+            */
+            insert_HTML(location_action_div, `<i class="material-icons location_choice_icon">check_box_outline_blank</i> ` + location.actions[key].action_name);
             choice_list.push(location_action_div);
         });
     } else if (category === "fast_travel") {

--- a/src/display.js
+++ b/src/display.js
@@ -1003,6 +1003,21 @@ function start_activity_animation(settings) {
     end_activity_animation();
     activity_anim = setInterval(() => { //sets a tiny little "animation" for activity text
         const action_status_div = document.getElementById("action_status_div");
+        /*
+            The interval outlives the element it animates. Anything that clears the
+            panel without also calling end_activity_animation leaves this reading
+            .innerText off null, and because it is a timer it does not throw once - it
+            throws on every beat, several times a second, until the page is reloaded.
+
+            Found in a fork whose travel path can do exactly that. I could not prove a
+            path to it in this tree, where end_activity_animation is called from a
+            dozen places and looks disciplined - so this is offered as the cheap half
+            of the fix: stop the timer rather than let it spin on nothing.
+        */
+        if(!action_status_div) {
+            end_activity_animation();
+            return;
+        }
         let end = "";
         if(action_status_div.innerText.endsWith("...")) {
             end = "...";


### PR DESCRIPTION
Two small, independent fixes to `src/display.js`, found while working from a fork. Each is its own commit and neither touches content.

### 1. The action button draws `starting_text`, not `action_name`

`GameAction` sets `this.action_name = data.action_name || data.starting_text`, but the button is built from `starting_text` directly, so a declared `action_name` never reaches the screen.

Seven actions declare one. Three of them are the ant nests — **Search for ant nests**, **Search for second ant nest** and **Search for third ant nests** — and all three render the *same* button, `Dig in search of red ant nests`, because that is the `starting_text` they share.

The unlock message *does* read `action_name`, so the log announces `Unlocked action "Search for second ant nest"` and the player then cannot find anything by that name on screen.

Reading `action_name` on the button changes only those seven. I checked the fallback against the model rather than assuming it:

| declared | button reads |
| --- | --- |
| no `action_name` | `Dig in search of red ant nests` (unchanged) |
| `action_name` | `Search for second ant nest` |

All 32 actions have at least one of the two fields, so nothing loses its label.

### 2. `start_activity_animation` can dereference null on a timer

The interval reads `document.getElementById("action_status_div").innerText` every beat, and it outlives the element. Anything that clears the panel without also calling `end_activity_animation` leaves this reading off `null` — and because it is a timer it does not throw once, it throws several times a second until the page is reloaded.

I hit this in a fork, where travelling out of a running action does exactly that. **I could not prove a path to it in this tree** — `end_activity_animation` is called from a dozen places here and looks disciplined — so this is offered as the cheap half of the fix: if the element is gone, stop the timer rather than let it spin on nothing. Two lines, no behaviour change while the element is present.

Happy to drop the second commit if you would rather not carry a defensive guard.

### Verification

No browser was available to me for this one, so: `esbuild src/main.js --bundle` builds the tree clean, and the fallback table above comes from constructing both action shapes against `src/models/game_action.js`. The reasoning for each fix is in its commit message and in a comment at the change.