### PR TITLE
Repair four broken imports in glassmaking, one case-sensitive path, and add the check that finds them

### DIFF
--- a/src/data/npcs.js
+++ b/src/data/npcs.js
@@ -4,7 +4,7 @@ import { availabilities, talkables } from "./component_references.js";
 import { dialogue_owners } from "../components/dialogue_component.js";
 import { equipments } from "../components/equipment_component.js";
 import { inventories } from "../components/inventory_component.js";
-import NPC from "../models/NPC.js";
+import NPC from "../models/npc.js";
 import { levels } from "./component_references.js";
 //import { bios } from "../models/person.js";
 import { dialogues } from "./dialogues.js";

--- a/src/mods/glassmaking.js
+++ b/src/mods/glassmaking.js
@@ -1,8 +1,10 @@
 "use strict";
 
-import { locations, LocationActivity } from "../locations.js"
+import { locations } from "../data/locations.js"
+import { LocationActivity } from "../models/location.js"
 import { Material, Book, BookData, item_templates, book_stats } from "../items.js"
-import { inventory_templates, TradeItem } from "../traders.js"
+import inventory_templates from "../data/inventory_templates.js"
+import { TradeItem } from "../models/trade_item.js"
 import { recipes, ItemRecipe } from "../crafting_recipes.js"
 
 console.log("Glassmaking mod loaded");

--- a/tests/imports-resolve.mjs
+++ b/tests/imports-resolve.mjs
@@ -1,0 +1,163 @@
+/**
+ * Every imported name exists in the module it is imported from.
+ *
+ *     node tests/imports-resolve.mjs
+ *
+ * Standalone and dependency-free, like tests/bundle-loads.mjs. Exits non-zero on a
+ * finding, so it can be a build step or left alone.
+ *
+ * The point: esbuild does not object to `import { update } from "./main.js"` when
+ * main.js has no such export. The bundle builds, the game runs, and the only thing that
+ * refuses is the browser's own module loader - so a repository that ships a bundle can
+ * carry a broken import for a long time and only the un-bundled page says so.
+ *
+ * Found three in src/mods/glassmaking.js, which had been importing from paths that
+ * moved into src/data/ and src/models/ and had not been loadable since.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const repo_root = path.resolve(import.meta.dirname, "..");
+
+/** Every .js file under src/, at any depth. */
+function source_files(dir, prefix = "src") {
+    const found = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const relative = `${prefix}/${entry.name}`;
+        if (entry.isDirectory()) {
+            found.push(...source_files(path.join(dir, entry.name), relative));
+        } else if (entry.name.endsWith(".js")) {
+            found.push(relative);
+        }
+    }
+    return found;
+}
+
+/*
+    Comments are blanked rather than removed, so every offset stays where it was and a
+    commented-out import cannot be mistaken for a live one.
+*/
+function strip_comments(source) {
+    return source
+        .replace(/\/\*[\s\S]*?\*\//g, block => block.replace(/[^\n]/g, " "))
+        .replace(/(^|[^:])\/\/[^\n]*/g, (line, before) =>
+            before + " ".repeat(line.length - before.length));
+}
+
+/*
+    Exists AND is spelled the way it was asked for.
+
+    fs.existsSync answers case-insensitively on Windows and macOS, so "../models/NPC.js"
+    looks fine on the machine it was written on and resolves to nothing on Linux. Walking
+    the directory listing instead compares against the real name on disk, so the answer
+    is the same everywhere - which is the point, since the platform that disagrees is
+    usually the one nobody runs the check on.
+*/
+function exists_with_exact_case(relative) {
+    let here = repo_root;
+    for (const segment of relative.split("/")) {
+        if (segment === "" || segment === ".") continue;
+        let listing;
+        try {
+            listing = fs.readdirSync(here);
+        } catch {
+            return false;
+        }
+        if (!listing.includes(segment)) return false;
+        here = path.join(here, segment);
+    }
+    return true;
+}
+
+const files = source_files(path.join(repo_root, "src"));
+
+//What each module offers, under the name an importer would ask for.
+const exported_by = new Map();
+for (const file of files) {
+    const source = strip_comments(fs.readFileSync(path.join(repo_root, file), "utf8"));
+    const names = new Set();
+    for (const block of source.matchAll(/export\s*\{([^}]*)\}/g)) {
+        for (const part of block[1].split(",")) {
+            const piece = part.trim();
+            if (!piece) continue;
+            //`a as b` is offered as b, which is the name an importer writes.
+            const halves = piece.split(/\s+as\s+/);
+            names.add((halves[1] ?? halves[0]).trim());
+        }
+    }
+    for (const inline of source.matchAll(
+            /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g)) {
+        names.add(inline[1]);
+    }
+    if (/export\s+default/.test(source)) {
+        names.add("default");
+    }
+    exported_by.set(file, names);
+}
+
+const problems = [];
+let checked = 0;
+for (const file of files) {
+    const source = strip_comments(fs.readFileSync(path.join(repo_root, file), "utf8"));
+
+    /*
+        Where a path points is asked of EVERY form of import, because the forms that
+        carry no braces are not the safe ones: `import NPC from "../models/NPC.js"` is
+        exactly how the case bug above was written.
+    */
+    for (const statement of source.matchAll(
+            /import\s+[^"';]*?from\s*["']([^"']+)["']|import\s*\(?\s*["']([^"']+)["']/g)) {
+        const target = statement[1] ?? statement[2];
+        //Only relative paths: a package or a node builtin is not this check's business.
+        if (!target.startsWith(".")) continue;
+
+        const resolved = path.posix.normalize(
+            path.posix.join(path.posix.dirname(file), target));
+        if (exported_by.has(resolved)) continue;
+        if (!exists_with_exact_case(resolved)) {
+            //Name the case trap outright, because on this machine it may look present.
+            const miscased = fs.existsSync(path.join(repo_root, resolved));
+            problems.push(miscased
+                ? `${file} imports from "${target}", which is spelled differently on `
+                  + `disk. It resolves here and will not resolve on Linux.`
+                : `${file} imports from "${target}", which resolves to no file.`);
+        }
+    }
+
+    //`import Default, { named } from` counts as well as `import { named } from`.
+    for (const block of source.matchAll(
+            /import\s+(?:\w+\s*,\s*)?\{([^}]*)\}\s*from\s*["']([^"']+)["']/g)) {
+        const target = block[2];
+        if (!target.startsWith(".")) continue;
+
+        const resolved = path.posix.normalize(
+            path.posix.join(path.posix.dirname(file), target));
+        const exports = exported_by.get(resolved);
+        /*
+            A path that resolves to nothing was reported above; do not say it twice. A
+            path that leaves src/ has no export list here, and nothing to say about it.
+        */
+        if (!exports) continue;
+
+        for (const part of block[1].split(",")) {
+            const piece = part.trim();
+            if (!piece) continue;
+            const name = piece.split(/\s+as\s+/)[0].trim();
+            if (!/^[A-Za-z_]\w*$/.test(name)) continue;
+            checked++;
+            if (!exports.has(name)) {
+                problems.push(`${file} imports "${name}" from ${target}, which does not export it.`);
+            }
+        }
+    }
+}
+
+if (problems.length > 0) {
+    console.error(`[imports] ${problems.length} unresolved import(s):`);
+    for (const problem of problems) {
+        console.error(`  ${problem}`);
+    }
+    process.exit(1);
+}
+console.log(`[imports] ${checked} imported names across ${files.length} files all resolve.`);


### PR DESCRIPTION
Two real fixes and one optional check, in separate commits so the check can be dropped without losing the fixes.

### `src/mods/glassmaking.js` does not build

It imports from `../locations.js` and `../traders.js`, and neither file exists any more:

| name | asked for | actually in |
|---|---|---|
| `locations` | `../locations.js` | `src/data/locations.js` |
| `LocationActivity` | `../locations.js` | `src/models/location.js` |
| `TradeItem` | `../traders.js` | `src/models/trade_item.js` |
| `inventory_templates` | `../traders.js` (named) | `src/data/inventory_templates.js`, as the **default** export |

With `build.js`'s own settings:

```
npx esbuild src/mods/glassmaking.js --bundle --format=esm --target=es2022
```

fails on all four before, builds after.

### `src/data/npcs.js` imports `../models/NPC.js`; the file is `npc.js`

Windows and macOS do not care about case, so it resolves for whoever wrote it. Linux does, so it resolves to nothing there. It is the only importer of that module, so lowercasing the one line is the whole fix.

### The check — take it or leave it

`tests/imports-resolve.mjs`, standalone and dependency-free like `tests/bundle-loads.mjs`, wired into nothing.

esbuild will bundle `import { update } from "./main.js"` when `main.js` exports no such name, and will resolve a miscased path on a filesystem that ignores case. The bundle builds and the page runs; what refuses is the browser's own module loader, or somebody else's machine. That is how glassmaking stayed broken.

It reads every import's path in **every** form — the formless ones are not the safe ones, since the case bug was a plain default import with no braces — checks the spelling against the real directory listing rather than `fs.existsSync` (which would have agreed with the bug on the machine that wrote it), and checks that every name in a `{ }` list is exported there.

Each of the three bugs was put back one at a time and is reported. On the clean tree: **492 imported names across 53 files, no false positives.**

```
$ node tests/imports-resolve.mjs
[imports] 492 imported names across 53 files all resolve.
```

Happy to drop the check commit, or the whole thing, if it is not to your taste.
